### PR TITLE
DBO+aclgrph

### DIFF
--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -174,7 +174,6 @@ def _make_metadata_with_slice(
     last_req = request_slice.stop - 1
     last_tok = token_slice.stop - 1
 
-    print(f"jcz _make_metadata_with_slice request_slice:{request_slice} token_slice:{token_slice} start_locs:{start_locs}")
     assert start_locs[first_req] <= first_tok < start_locs[first_req + 1], \
         "Token slice start outside of first request"
     assert start_locs[last_req] <= last_tok < start_locs[last_req+1], \

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -174,6 +174,7 @@ def _make_metadata_with_slice(
     last_req = request_slice.stop - 1
     last_tok = token_slice.stop - 1
 
+    print(f"jcz _make_metadata_with_slice request_slice:{request_slice} token_slice:{token_slice} start_locs:{start_locs}")
     assert start_locs[first_req] <= first_tok < start_locs[first_req + 1], \
         "Token slice start outside of first request"
     assert start_locs[last_req] <= last_tok < start_locs[last_req+1], \

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -9,6 +9,7 @@ __all__ = ["AFDConnectorBase", "AFDConnectorMetadata", "AFDConnectorFactory"]
 
 import torch_npu
 import torch
+import pickle
 
 from torch.distributed.distributed_c10d import _get_default_group
 import re
@@ -75,34 +76,70 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         self.attn_size, self.ffn_size = map(
             int,
             re.match(r"(\d+)\D+(\d+)", afd_size).groups())
-        #ffn_ranks = [i for i in range(ffn_size, ffn_size + attn_size)]
-        #attn_ranks = [i for i in range(attn_size)]
-        # self rank atten:0 ffn:0
-        self.rank = self.rank + self.ffn_size if role == "attention" else self.rank
 
+        self.min_size = min(self.ffn_size, self.attn_size)
+        world_rank = self.rank + self.ffn_size if role == "attention" else self.rank
+        # p2p_rank: 所有FFN [0, ffn_size), 前min_size个Attention [ffn_size, ffn_size+min_size)
+        self.p2p_rank = self.rank + self.min_size if role == "attention" else self.rank
+        self.rank = world_rank
 
-        logger.info(
+        print(f"world_size = {self.ffn_size + self.attn_size}, world_rank = {self.rank}")
+        logger.debug(
             f"world_size = {self.ffn_size + self.attn_size}, world_rank = {self.rank}")
         # TODO(jcz) : 这里要根据实际的num_of_stages创建，需要改成list
         self.afd_pg = init_afd_process_group(
             backend="hccl",
-            init_method=f"tcp://127.0.0.1:29888",
+            init_method=(
+                f"tcp://{self.config.afd_config.afd_host}"
+                f":{self.config.afd_config.afd_port}"
+            ),
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd"
         )
         self.afd_pg2 = init_afd_process_group(
             backend="hccl",
-            init_method=f"tcp://127.0.0.1:29888",
+            init_method=(
+                f"tcp://{self.config.afd_config.afd_host}"
+                f":{self.config.afd_config.afd_port}"
+            ),
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd2"
         )
+        
         self.hccl_comm_name = self.afd_pg._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
         self.hccl_comm_name2 = self.afd_pg2._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
         ffn_ranks = [i for i in range(0, self.ffn_size)]
         attn_ranks = [i for i in range(self.ffn_size, self.ffn_size + self.attn_size)]
 
+        # # 所有FFN和前min_size的Attention参与p2p通信
+        # # 所有FFN: world_rank in [0, ffn_size), 前min_size个Attention: world_rank in [ffn_size, ffn_size+min_size)
+        # if self.rank < self.ffn_size or (self.rank >= self.ffn_size and self.rank < self.ffn_size + self.min_size):
+        #     self.p2p_pg = init_afd_process_group(
+        #         backend="gloo",
+        #         init_method=(
+        #             f"tcp://{self.config.afd_config.afd_host}"
+        #             f":{self.config.afd_config.afd_port}"
+        #         ),
+        #         world_size=self.ffn_size + self.min_size,
+        #         rank=self.p2p_rank,
+        #         group_name="p2p"
+        #     )
+
+        # # 前min_size的Attention向多个FFN发送metadata（1对多映射）
+        # # attn_i 向所有 ffn_j (其中 j % min_size == i) 发送
+        # if self.rank >= self.ffn_size and self.rank < self.ffn_size + self.min_size:
+        #     local_attn_rank = self.rank - self.ffn_size
+        #     dst = local_attn_rank
+        #     while dst < self.ffn_size:
+        #         self.dst_list.append(dst)
+        #         dst += self.min_size
+        # print(f"[CAM] world_rank={self.rank}, p2p_rank={self.p2p_rank}, min_size={self.min_size}, "
+        #             f"dst_list={self.dst_list}, cam connector initialized")
+        # logger.debug(f"[CAM] world_rank={self.rank}, p2p_rank={self.p2p_rank}, min_size={self.min_size}, "
+        #             f"dst_list={self.dst_list}, cam connector initialized")
+        
         default_pg_switcher = DefaultProcessGroupSwitcher(
             _get_default_group(), self.afd_pg)
         # TODO(yxj):m2n ae_group is different
@@ -137,45 +174,15 @@ class CAMM2NAFDConnector(AFDConnectorBase):
                          topk_idx:torch.Tensor, 
                          metadata: AFDConnectorMetadata,
                          ubatch_idx: int = 0) -> Any:
-        if not self.use_aclgraph and self.ffn_size <= self.rank < self.ffn_size + self.min_size:
-            for dst in self.dst_list:
-                # Serialize object to tensor and get the size as well
-                object_tensor = torch.frombuffer(pickle.dumps(metadata), dtype=torch.uint8)
-
-                size_tensor = torch.tensor([object_tensor.numel()],
-                                           dtype=torch.long,
-                                           device="cpu")
-                # Send object size
-                torch.distributed.send(size_tensor,
-                                       dst=dst,
-                                       group=self.p2p_pg)
-
-                # Send object
-                torch.distributed.send(object_tensor,
-                                       dst=dst,
-                                       group=self.p2p_pg)
-                print(f'attn_src_rank: {self.rank} send_attn_output metadata success')
-        
-        # batch_size = metadata.cam_afdconnector_data.batch_size
-        # h = metadata.cam_afdconnector_data.h
-        # k = metadata.cam_afdconnector_data.k
-        # moe_expert_num = metadata.cam_afdconnector_data.moe_expert_num
-        # shared_expert_num = metadata.cam_afdconnector_data.shared_expert_num
-        # quant_mode = metadata.cam_afdconnector_data.quant_mode
-        # aiv_num = metadata.cam_afdconnector_data.aiv_num
-        # expandXOutDType = torch.tensor([], dtype=torch.bfloat16 if not quant_mode else torch.int8, device='npu')
-
-        # handle_out = torch_npu.cam_a2e(expandX = hidden_states, expertIds = topk_idx,
-        #                     scales = topk_weights, commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
-        #                     expandXOutDType = expandXOutDType,
-        #                     commId = 0, batchSize = batch_size, hiddenSize = h, topk = k,
-        #                     expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
-        #                     sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num, rank = self.rank,
-        #                     loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant = quant_mode,
-        #                     groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
-        #                     aivNum = aiv_num)
-
-        # return handle_out
+        # if not self.use_aclgraph and self.ffn_size <= self.rank < self.ffn_size + self.min_size:
+        #     for dst in self.dst_list:
+        #         self.send_metadata(metadata,dst,self.p2p_pg)
+        if not self.use_aclgraph:
+            print(f'send_attn_output start rank:{self.rank}')
+            dst = (self.process_group.rank_in_group + 1) % self.process_group.world_size
+            print(f'send_attn_output dst is {dst}')
+            self.process_group.send_object(metadata,dst)
+            
         return torch.ops.vllm.cam_send_attn_output(hidden_states, topk_weights, topk_idx,
                                                 self.hccl_comm_name,
                                                 self.hccl_comm_name2,
@@ -185,29 +192,6 @@ class CAMM2NAFDConnector(AFDConnectorBase):
 
     # MOE发给ATTN（ATTN接收）
     def recv_ffn_output(self, hidden_states: torch.Tensor, metadata: AFDConnectorMetadata, ubatch_idx: int = 0) -> torch.Tensor:
-        # batch_size = metadata.cam_afdconnector_data.batch_size
-        # h = metadata.cam_afdconnector_data.h
-        # k = metadata.cam_afdconnector_data.k
-        # moe_expert_num = metadata.cam_afdconnector_data.moe_expert_num
-        # shared_expert_num = metadata.cam_afdconnector_data.shared_expert_num
-        # aiv_num = metadata.cam_afdconnector_data.aiv_num
-        # handle = metadata.cam_afdconnector_data.handle
-        
-        # output2 = torch_npu.cam_e2a(expandXOut = hidden_states, simulateExpertIds = handle[0],
-        #                     simulateExpertScales = handle[1], expandIdx = handle[2],
-        #                     epRecvCounts = handle[3],
-        #                     commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
-        #                     attenBatchSize = handle[4],
-        #                     commId = 0,
-        #                     batchSize = batch_size, hiddenSize = h, topk = k,
-        #                     expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
-        #                     sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num,
-        #                     rank = self.rank,
-        #                     loadBalancingRankNum=1, loadBalancingThreshold=0,
-        #                     groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
-        #                     aivNum = aiv_num)
-
-        # return output2
         return torch.ops.vllm.cam_recv_ffn_output(hidden_states,
                                                 self.hccl_comm_name,
                                                 self.hccl_comm_name2,
@@ -244,11 +228,13 @@ class CAMM2NAFDConnector(AFDConnectorBase):
     
     # ATTN发给MOE(MOE接收)
     def recv_attn_output(self, metadata: CAMM2NAFDConnectorMetadata, ubatch_idx: int = 0) -> Any: 
+        # afdConnectorMetadata = None
+        # if not self.use_aclgraph and self.rank >= self.attn_size:
+        #     afdConnectorMetadata = self.recv_metadata()
         afdmetadata = None
         if not self.use_aclgraph:
             src = (self.process_group.rank_in_group - 1) % self.process_group.world_size
             afdmetadata = self.process_group.recv_object(src)
-
             print(f'recv_attn_output start rank:{self.rank}')
 
         batch_size = metadata.batch_size
@@ -271,6 +257,53 @@ class CAMM2NAFDConnector(AFDConnectorBase):
                             aivNum = aiv_num)
         
         return output1, afdmetadata
+    
+    def send_metadata(self,data,dst,group):
+        # Serialize object to tensor and get the size as well
+        object_tensor = torch.frombuffer(pickle.dumps(data), dtype=torch.uint8)
+
+        size_tensor = torch.tensor([object_tensor.numel()],
+                                    dtype=torch.long,
+                                    device="cpu")
+        # Send object size
+        torch.distributed.send(size_tensor,
+                                dst=dst,
+                                group=group)
+
+        # Send object
+        torch.distributed.send(object_tensor,
+                                dst=dst,
+                                group=group)
+        
+    def recv_metadata(self):
+        src = self.p2p_rank % self.min_size
+        print(f'src in recv_metadata is {src}')
+        print(f'self.p2p_rank in recv_metadata is {self.p2p_rank}')
+        print(f'self.min_size in recv_metadata is {self.min_size}')
+        size_tensor = torch.empty(1, dtype=torch.long, device="cpu")
+
+        # Receive object size
+        rank_size = torch.distributed.recv(size_tensor,
+                                        src=src,
+                                        group=self.p2p_pg)
+
+        # Tensor to receive serialized objects into.
+        object_tensor = torch.empty(  # type: ignore[call-overload]
+            size_tensor.item(),  # type: ignore[arg-type]
+            dtype=torch.uint8,
+            device="cpu")
+
+        rank_object = torch.distributed.recv(object_tensor,
+                                            src=src,
+                                            group=group)
+
+        assert rank_object == rank_size, (
+            "Received object sender rank does not match the size sender rank.")
+
+        data = pickle.loads(object_tensor.numpy().tobytes())
+        print(f'recv_attn_output afdConnectorMetadata success')
+        
+        return data
 
 def cam_send_attn_output_impl(hidden_states: torch.Tensor,
                               topk_weights: torch.Tensor,
@@ -282,7 +315,7 @@ def cam_send_attn_output_impl(hidden_states: torch.Tensor,
                               attn_size: int) -> torch.Tensor:
     ubatch_idx = get_forward_context().ubatch_idx
     if get_forward_context().cam_afdconnector_data is None:
-        cam_afdconnector_data = CAMAFDConnectorMetadata(
+        cam_afdconnector_data = CAMM2NAFDConnectorMetadata(
             moe_expert_num = 64,
             shared_expert_num = 0,
             scale = None,
@@ -365,6 +398,8 @@ def cam_recv_ffn_output_impl(hidden_states: torch.Tensor,
                         aivNum = aiv_num)
 
     return output2
+
+    
 
 def cam_recv_ffn_output_fake_impl(hidden_states: torch.Tensor,
                                   hccl_comm_name: str,

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -86,14 +86,14 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         # TODO(jcz) : 这里要根据实际的num_of_stages创建，需要改成list
         self.afd_pg = init_afd_process_group(
             backend="hccl",
-            init_method=f"tcp://127.0.0.1:29811",
+            init_method=f"tcp://127.0.0.1:29888",
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd"
         )
         self.afd_pg2 = init_afd_process_group(
             backend="hccl",
-            init_method=f"tcp://127.0.0.1:29811",
+            init_method=f"tcp://127.0.0.1:29888",
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd2"

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from typing import Any
 
 from vllm.distributed.afd_transfer.afd_connector import (AFDConnectorBase, AFDConnectorFactory,
-                                                         AFDConnectorMetadata)
+                            AFDConnectorMetadata)
+
 
 __all__ = ["AFDConnectorBase", "AFDConnectorMetadata", "AFDConnectorFactory"]
 
@@ -13,19 +14,17 @@ from torch.distributed.distributed_c10d import _get_default_group
 import re
 
 import torch
-import pickle
-from torch.distributed.distributed_c10d import _update_default_pg, _get_default_group
+from torch.distributed.distributed_c10d import  _update_default_pg, _get_default_group
 
-from vllm.distributed.parallel_state import init_afd_process_group
+from vllm.distributed.parallel_state import init_afd_process_group, init_model_parallel_group
 from vllm.logger import init_logger
 from vllm.config import VllmConfig
 from vllm.distributed.afd_transfer.afd_connector.metadata import (CAMM2NAFDConnectorMetadata)
-from vllm.config import VllmConfig, CUDAGraphMode, CompilationLevel
-
+from vllm.config import VllmConfig,CUDAGraphMode,CompilationLevel
+from vllm.distributed.afd_transfer.afd_connector.p2p_connector import DefaultProcessGroupSwitcher
 logger = init_logger(__name__)
 
-
-# # TODO(yxj):move to ascend ,use kwargs
+# # TODO(yxj):move to ascend ,use kwargs 
 # @dataclass
 # class CAMM2NAFDConnectorMetadata:
 #     def __init__(self):
@@ -64,7 +63,7 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         """Close the connector and release resources."""
         # destroy process group
         pass
-
+    
     def init_afd_connector(self) -> None:
         """Initialize the AFD connector."""
         afd_size = self.config.afd_config.afd_extra_config.get("afd_size")
@@ -72,57 +71,51 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         self.attn_size, self.ffn_size = map(
             int,
             re.match(r"(\d+)\D+(\d+)", afd_size).groups())
-        # ffn_ranks = [i for i in range(ffn_size, ffn_size + attn_size)]
-        # attn_ranks = [i for i in range(attn_size)]
-        self.min_size = min(self.ffn_size, self.attn_size)
-        world_rank = self.rank + self.ffn_size if role == "attention" else self.rank
-        # p2p_rank: 所有FFN [0, ffn_size), 前min_size个Attention [ffn_size, ffn_size+min_size)
-        self.p2p_rank = self.rank + self.ffn_size if role == "attention" else self.rank
-        self.rank = world_rank
+        #ffn_ranks = [i for i in range(ffn_size, ffn_size + attn_size)]
+        #attn_ranks = [i for i in range(attn_size)]
+        # self rank atten:0 ffn:0
+        self.rank = self.rank + self.ffn_size if role == "attention" else self.rank
+
 
         logger.info(
-            f"world_size = {self.ffn_size + self.attn_size}, world_rank = {self.rank}, "
-            f"afd_hots: {self.config.afd_config.afd_host}, afd_port: {self.config.afd_config.afd_port}")
-        # TODO : get backend to replace hardcode
+            f"world_size = {self.ffn_size + self.attn_size}, world_rank = {self.rank}")
+        # TODO(jcz) : 这里要根据实际的num_of_stages创建，需要改成list
         self.afd_pg = init_afd_process_group(
             backend="hccl",
-            init_method=(
-                f"tcp://{self.config.afd_config.afd_host}"
-                f":{self.config.afd_config.afd_port}"
-            ),
+            init_method=f"tcp://127.0.0.1:29777",
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd"
         )
+        self.afd_pg2 = init_afd_process_group(
+            backend="hccl",
+            init_method=f"tcp://127.0.0.1:29777",
+            world_size=self.ffn_size + self.attn_size,
+            rank=self.rank,
+            group_name="afd2"
+        )
         self.hccl_comm_name = self.afd_pg._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
-        # 所有FFN和前min_size的Attention参与p2p通信
-        # 所有FFN: world_rank in [0, ffn_size), 前min_size个Attention: world_rank in [ffn_size, ffn_size+min_size)
-        if self.rank < self.ffn_size or (self.rank >= self.ffn_size and self.rank < self.ffn_size + self.min_size):
-            self.p2p_pg = init_afd_process_group(
-                backend="gloo",
-                init_method=(
-                    f"tcp://{self.config.afd_config.afd_host}"
-                    f":{self.config.afd_config.afd_port}"
-                ),
-                world_size=self.ffn_size + self.min_size,
-                rank=self.p2p_rank,
-                group_name="p2p"
-            )
+        self.hccl_comm_name2 = self.afd_pg2._get_backend(torch.device("npu")).get_hccl_comm_name(self.rank)
+        ffn_ranks = [i for i in range(0, self.ffn_size)]
+        attn_ranks = [i for i in range(self.ffn_size, self.ffn_size + self.attn_size)]
 
-        # 前min_size的Attention向多个FFN发送metadata（1对多映射）
-        # attn_i 向所有 ffn_j (其中 j % min_size == i) 发送
-        if self.rank >= self.ffn_size and self.rank < self.ffn_size + self.min_size:
-            local_attn_rank = self.rank - self.ffn_size
-            dst = local_attn_rank
-            while dst < self.ffn_size:
-                self.dst_list.append(dst)
-                dst += self.min_size
+        default_pg_switcher = DefaultProcessGroupSwitcher(
+            _get_default_group(), self.afd_pg)
+        # TODO(yxj):m2n ae_group is different
+        with default_pg_switcher:
+            sub_group_ranks = []
+            for i in range(len(ffn_ranks)):
+                ranks = list([attn_ranks[i], ffn_ranks[i]])
+                sub_group_ranks.append(ranks)
+            self.process_group = init_model_parallel_group(sub_group_ranks,
+                                                 self.rank,
+                                                 backend="hccl",
+                                                 group_name="ae")
 
-        logger.info(f"[CAM] world_rank={self.rank}, p2p_rank={self.p2p_rank}, min_size={self.min_size}, "
-                    f"dst_list={self.dst_list}, cam connector initialized")
+        logger.info("m2n connector initialized")
 
         self._initialized = True
-
+    
     def is_initialized(self) -> bool:
         """Check if the connector is initialized and ready to use.
         
@@ -130,15 +123,16 @@ class CAMM2NAFDConnector(AFDConnectorBase):
             bool: True if the connector is initialized, False otherwise.
         """
         return self._initialized
-
+                                  
     # ATTN发给MOE（ATTN发送）
     # TODO:metadata的获取，最好从框架侧去拿
-    def send_attn_output(self,
-                         hidden_states: torch.Tensor,
-                         topk_weights: torch.Tensor,
-                         topk_idx: torch.Tensor,
-                         metadata: AFDConnectorMetadata) -> Any:
-        # 只有前min_size的Attention发送metadata
+    # TODO(jcz): 这里ubatch_idx的入参需要优化
+    def send_attn_output(self, 
+                         hidden_states: torch.Tensor,  
+                         topk_weights: torch.Tensor, 
+                         topk_idx:torch.Tensor, 
+                         metadata: AFDConnectorMetadata,
+                         ubatch_idx: int = 0) -> Any:
         if not self.use_aclgraph and self.ffn_size <= self.rank < self.ffn_size + self.min_size:
             for dst in self.dst_list:
                 # Serialize object to tensor and get the size as well
@@ -157,7 +151,7 @@ class CAMM2NAFDConnector(AFDConnectorBase):
                                        dst=dst,
                                        group=self.p2p_pg)
                 print(f'attn_src_rank: {self.rank} send_attn_output metadata success')
-
+        
         batch_size = metadata.cam_m2n_afdconnector_data.batch_size
         h = metadata.cam_m2n_afdconnector_data.h
         k = metadata.cam_m2n_afdconnector_data.k
@@ -167,22 +161,20 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         aiv_num = metadata.cam_m2n_afdconnector_data.aiv_num
         expandXOutDType = torch.tensor([], dtype=torch.bfloat16 if not quant_mode else torch.int8, device='npu')
 
-        handle_out = torch_npu.cam_a2e(expandX=hidden_states, expertIds=topk_idx,
-                                       scales=topk_weights,
-                                       commArgs=torch.tensor([], dtype=torch.float16, device='npu'),
-                                       expandXOutDType=expandXOutDType,
-                                       commId=0, batchSize=batch_size, hiddenSize=h, topk=k,
-                                       expertRankSize=self.ffn_size, attentionRankSize=self.attn_size,
-                                       sharedExpertNum=shared_expert_num,
-                                       totalExpertNum=moe_expert_num + shared_expert_num, rank=self.rank,
-                                       loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant=quant_mode,
-                                       groupEp=self.hccl_comm_name,
-                                       aivNum=aiv_num)
+        handle_out = torch_npu.cam_a2e(expandX = hidden_states, expertIds = topk_idx,
+                            scales = topk_weights, commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+                            expandXOutDType = expandXOutDType,
+                            commId = 0, batchSize = batch_size, hiddenSize = h, topk = k,
+                            expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
+                            sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num, rank = self.rank,
+                            loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant = quant_mode,
+                            groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
+                            aivNum = aiv_num)
 
         return handle_out
 
     # MOE发给ATTN（ATTN接收）
-    def recv_ffn_output(self, hidden_states: torch.Tensor, metadata: AFDConnectorMetadata) -> torch.Tensor:
+    def recv_ffn_output(self, hidden_states: torch.Tensor, metadata: AFDConnectorMetadata, ubatch_idx: int = 0) -> torch.Tensor:
         batch_size = metadata.cam_m2n_afdconnector_data.batch_size
         h = metadata.cam_m2n_afdconnector_data.h
         k = metadata.cam_m2n_afdconnector_data.k
@@ -190,26 +182,25 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         shared_expert_num = metadata.cam_m2n_afdconnector_data.shared_expert_num
         aiv_num = metadata.cam_m2n_afdconnector_data.aiv_num
         handle = metadata.cam_m2n_afdconnector_data.handle
-
-        output2 = torch_npu.cam_e2a(expandXOut=hidden_states, simulateExpertIds=handle[0],
-                                    simulateExpertScales=handle[1], expandIdx=handle[2],
-                                    epRecvCounts=handle[3],
-                                    commArgs=torch.tensor([], dtype=torch.float16, device='npu'),
-                                    attenBatchSize=handle[4],
-                                    commId=0,
-                                    batchSize=batch_size, hiddenSize=h, topk=k,
-                                    expertRankSize=self.ffn_size, attentionRankSize=self.attn_size,
-                                    sharedExpertNum=shared_expert_num,
-                                    totalExpertNum=moe_expert_num + shared_expert_num,
-                                    rank=self.rank,
-                                    loadBalancingRankNum=1, loadBalancingThreshold=0,
-                                    groupEp=self.hccl_comm_name,
-                                    aivNum=aiv_num)
+        
+        output2 = torch_npu.cam_e2a(expandXOut = hidden_states, simulateExpertIds = handle[0],
+                            simulateExpertScales = handle[1], expandIdx = handle[2],
+                            epRecvCounts = handle[3],
+                            commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+                            attenBatchSize = handle[4],
+                            commId = 0,
+                            batchSize = batch_size, hiddenSize = h, topk = k,
+                            expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
+                            sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num,
+                            rank = self.rank,
+                            loadBalancingRankNum=1, loadBalancingThreshold=0,
+                            groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
+                            aivNum = aiv_num)
 
         return output2
-
+    
     # MOE发给ATTN(MOE发送) 
-    def send_ffn_output(self, ffn_output: torch.Tensor, metadata: CAMM2NAFDConnectorMetadata):
+    def send_ffn_output(self, ffn_output: torch.Tensor, metadata: CAMM2NAFDConnectorMetadata, ubatch_idx: int = 0):
         batch_size = metadata.batch_size
         h = metadata.h
         k = metadata.k
@@ -217,53 +208,32 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         shared_expert_num = metadata.shared_expert_num
         aiv_num = metadata.aiv_num
         handle = metadata.handle
-
-        torch_npu.cam_e2a(expandXOut=ffn_output, simulateExpertIds=handle[0],
-                          simulateExpertScales=handle[1],
-                          expandIdx=handle[2],
-                          epRecvCounts=handle[3],
-                          commArgs=torch.tensor([], dtype=torch.float16, device='npu'),
-                          attenBatchSize=handle[4],
-                          commId=0,
-                          batchSize=batch_size, hiddenSize=h, topk=k,
-                          expertRankSize=self.ffn_size, attentionRankSize=self.attn_size,
-                          sharedExpertNum=shared_expert_num, totalExpertNum=moe_expert_num + shared_expert_num,
-                          rank=self.rank,
-                          loadBalancingRankNum=1, loadBalancingThreshold=0,
-                          groupEp=self.hccl_comm_name,
-                          aivNum=aiv_num)
+        
+        torch_npu.cam_e2a(expandXOut = ffn_output, simulateExpertIds = handle[0],
+                            simulateExpertScales = handle[1],
+                            expandIdx = handle[2],
+                            epRecvCounts = handle[3],
+                            commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+                            attenBatchSize = handle[4],
+                            commId = 0,
+                            batchSize = batch_size, hiddenSize = h, topk = k,
+                            expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
+                            sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num,
+                            rank = self.rank,
+                            loadBalancingRankNum=1, loadBalancingThreshold=0,
+                            groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
+                            aivNum = aiv_num)
 
         return
-
+    
     # ATTN发给MOE(MOE接收)
-    def recv_attn_output(self, metadata: CAMM2NAFDConnectorMetadata) -> Any:
+    def recv_attn_output(self, metadata: CAMM2NAFDConnectorMetadata, ubatch_idx: int = 0) -> Any: 
         afdmetadata = None
-        if not self.use_aclgraph and self.rank < self.ffn_size:
-            local_ffn_rank = self.rank
-            src = (local_ffn_rank % self.min_size) + self.ffn_size  # 对应的Attention在p2p组中的rank
-            print(f'rank: {self.rank}, recv_attn_output src is {src}')
-            size_tensor = torch.empty(1, dtype=torch.long, device="cpu")
+        if not self.use_aclgraph:
+            src = (self.process_group.rank_in_group - 1) % self.process_group.world_size
+            afdmetadata = self.process_group.recv_object(src)
 
-            # Receive object size
-            rank_size = torch.distributed.recv(size_tensor,
-                                               src=src,
-                                               group=self.p2p_pg)
-
-            # Tensor to receive serialized objects into.
-            object_tensor = torch.empty(  # type: ignore[call-overload]
-                size_tensor.item(),  # type: ignore[arg-type]
-                dtype=torch.uint8,
-                device="cpu")
-
-            rank_object = torch.distributed.recv(object_tensor,
-                                                 src=src,
-                                                 group=self.p2p_pg)
-
-            assert rank_object == rank_size, (
-                "Received object sender rank does not match the size sender rank.")
-
-            afdmetadata = pickle.loads(object_tensor.numpy().tobytes())
-            print(f'recv_attn_output afdConnectorMetadata success')
+            print(f'recv_attn_output start rank:{self.rank}')
 
         batch_size = metadata.batch_size
         h = metadata.h
@@ -274,17 +244,14 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         aiv_num = metadata.aiv_num
         expandXOutDType = torch.tensor([], dtype=torch.bfloat16 if not quant_mode else torch.int8, device='npu')
 
-        output1 = torch_npu.cam_a2e(expandX=torch.tensor([], dtype=torch.bfloat16, device='npu'),
-                                    expertIds=torch.tensor([], dtype=torch.int32, device='npu'),
-                                    scales=torch.tensor([], dtype=torch.float, device='npu'),
-                                    commArgs=torch.tensor([], dtype=torch.float16, device='npu'),
-                                    expandXOutDType=expandXOutDType,
-                                    commId=0, batchSize=batch_size, hiddenSize=h, topk=k,
-                                    expertRankSize=self.ffn_size, attentionRankSize=self.attn_size,
-                                    sharedExpertNum=shared_expert_num,
-                                    totalExpertNum=moe_expert_num + shared_expert_num, rank=self.rank,
-                                    loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant=quant_mode,
-                                    groupEp=self.hccl_comm_name,
-                                    aivNum=aiv_num)
-
+        output1 = torch_npu.cam_a2e(expandX = torch.tensor([], dtype=torch.bfloat16, device='npu'), expertIds = torch.tensor([], dtype=torch.int32, device='npu'),
+                            scales = torch.tensor([], dtype=torch.float, device='npu'), commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+                            expandXOutDType = expandXOutDType,
+                            commId = 0, batchSize = batch_size, hiddenSize = h, topk = k,
+                            expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
+                            sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num, rank = self.rank,
+                            loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant = quant_mode,
+                            groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
+                            aivNum = aiv_num)
+        
         return output1, afdmetadata

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -22,6 +22,10 @@ from vllm.config import VllmConfig
 from vllm.distributed.afd_transfer.afd_connector.metadata import (CAMM2NAFDConnectorMetadata)
 from vllm.config import VllmConfig,CUDAGraphMode,CompilationLevel
 from vllm.distributed.afd_transfer.afd_connector.p2p_connector import DefaultProcessGroupSwitcher
+
+from vllm.utils import direct_register_custom_op
+from vllm.forward_context import ForwardContext, get_forward_context
+
 logger = init_logger(__name__)
 
 # # TODO(yxj):move to ascend ,use kwargs 
@@ -82,14 +86,14 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         # TODO(jcz) : 这里要根据实际的num_of_stages创建，需要改成list
         self.afd_pg = init_afd_process_group(
             backend="hccl",
-            init_method=f"tcp://127.0.0.1:29777",
+            init_method=f"tcp://127.0.0.1:29811",
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd"
         )
         self.afd_pg2 = init_afd_process_group(
             backend="hccl",
-            init_method=f"tcp://127.0.0.1:29777",
+            init_method=f"tcp://127.0.0.1:29811",
             world_size=self.ffn_size + self.attn_size,
             rank=self.rank,
             group_name="afd2"
@@ -152,52 +156,64 @@ class CAMM2NAFDConnector(AFDConnectorBase):
                                        group=self.p2p_pg)
                 print(f'attn_src_rank: {self.rank} send_attn_output metadata success')
         
-        batch_size = metadata.cam_m2n_afdconnector_data.batch_size
-        h = metadata.cam_m2n_afdconnector_data.h
-        k = metadata.cam_m2n_afdconnector_data.k
-        moe_expert_num = metadata.cam_m2n_afdconnector_data.moe_expert_num
-        shared_expert_num = metadata.cam_m2n_afdconnector_data.shared_expert_num
-        quant_mode = metadata.cam_m2n_afdconnector_data.quant_mode
-        aiv_num = metadata.cam_m2n_afdconnector_data.aiv_num
-        expandXOutDType = torch.tensor([], dtype=torch.bfloat16 if not quant_mode else torch.int8, device='npu')
+        # batch_size = metadata.cam_afdconnector_data.batch_size
+        # h = metadata.cam_afdconnector_data.h
+        # k = metadata.cam_afdconnector_data.k
+        # moe_expert_num = metadata.cam_afdconnector_data.moe_expert_num
+        # shared_expert_num = metadata.cam_afdconnector_data.shared_expert_num
+        # quant_mode = metadata.cam_afdconnector_data.quant_mode
+        # aiv_num = metadata.cam_afdconnector_data.aiv_num
+        # expandXOutDType = torch.tensor([], dtype=torch.bfloat16 if not quant_mode else torch.int8, device='npu')
 
-        handle_out = torch_npu.cam_a2e(expandX = hidden_states, expertIds = topk_idx,
-                            scales = topk_weights, commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
-                            expandXOutDType = expandXOutDType,
-                            commId = 0, batchSize = batch_size, hiddenSize = h, topk = k,
-                            expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
-                            sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num, rank = self.rank,
-                            loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant = quant_mode,
-                            groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
-                            aivNum = aiv_num)
+        # handle_out = torch_npu.cam_a2e(expandX = hidden_states, expertIds = topk_idx,
+        #                     scales = topk_weights, commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+        #                     expandXOutDType = expandXOutDType,
+        #                     commId = 0, batchSize = batch_size, hiddenSize = h, topk = k,
+        #                     expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
+        #                     sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num, rank = self.rank,
+        #                     loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant = quant_mode,
+        #                     groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
+        #                     aivNum = aiv_num)
 
-        return handle_out
+        # return handle_out
+        return torch.ops.vllm.cam_send_attn_output(hidden_states, topk_weights, topk_idx,
+                                                self.hccl_comm_name,
+                                                self.hccl_comm_name2,
+                                                self.rank,
+                                                self.ffn_size,
+                                                self.attn_size)
 
     # MOE发给ATTN（ATTN接收）
     def recv_ffn_output(self, hidden_states: torch.Tensor, metadata: AFDConnectorMetadata, ubatch_idx: int = 0) -> torch.Tensor:
-        batch_size = metadata.cam_m2n_afdconnector_data.batch_size
-        h = metadata.cam_m2n_afdconnector_data.h
-        k = metadata.cam_m2n_afdconnector_data.k
-        moe_expert_num = metadata.cam_m2n_afdconnector_data.moe_expert_num
-        shared_expert_num = metadata.cam_m2n_afdconnector_data.shared_expert_num
-        aiv_num = metadata.cam_m2n_afdconnector_data.aiv_num
-        handle = metadata.cam_m2n_afdconnector_data.handle
+        # batch_size = metadata.cam_afdconnector_data.batch_size
+        # h = metadata.cam_afdconnector_data.h
+        # k = metadata.cam_afdconnector_data.k
+        # moe_expert_num = metadata.cam_afdconnector_data.moe_expert_num
+        # shared_expert_num = metadata.cam_afdconnector_data.shared_expert_num
+        # aiv_num = metadata.cam_afdconnector_data.aiv_num
+        # handle = metadata.cam_afdconnector_data.handle
         
-        output2 = torch_npu.cam_e2a(expandXOut = hidden_states, simulateExpertIds = handle[0],
-                            simulateExpertScales = handle[1], expandIdx = handle[2],
-                            epRecvCounts = handle[3],
-                            commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
-                            attenBatchSize = handle[4],
-                            commId = 0,
-                            batchSize = batch_size, hiddenSize = h, topk = k,
-                            expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
-                            sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num,
-                            rank = self.rank,
-                            loadBalancingRankNum=1, loadBalancingThreshold=0,
-                            groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
-                            aivNum = aiv_num)
+        # output2 = torch_npu.cam_e2a(expandXOut = hidden_states, simulateExpertIds = handle[0],
+        #                     simulateExpertScales = handle[1], expandIdx = handle[2],
+        #                     epRecvCounts = handle[3],
+        #                     commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+        #                     attenBatchSize = handle[4],
+        #                     commId = 0,
+        #                     batchSize = batch_size, hiddenSize = h, topk = k,
+        #                     expertRankSize = self.ffn_size, attentionRankSize = self.attn_size,
+        #                     sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num,
+        #                     rank = self.rank,
+        #                     loadBalancingRankNum=1, loadBalancingThreshold=0,
+        #                     groupEp = self.hccl_comm_name2 if ubatch_idx == 1 else self.hccl_comm_name,
+        #                     aivNum = aiv_num)
 
-        return output2
+        # return output2
+        return torch.ops.vllm.cam_recv_ffn_output(hidden_states,
+                                                self.hccl_comm_name,
+                                                self.hccl_comm_name2,
+                                                self.rank,
+                                                self.ffn_size,
+                                                self.attn_size)
     
     # MOE发给ATTN(MOE发送) 
     def send_ffn_output(self, ffn_output: torch.Tensor, metadata: CAMM2NAFDConnectorMetadata, ubatch_idx: int = 0):
@@ -255,3 +271,117 @@ class CAMM2NAFDConnector(AFDConnectorBase):
                             aivNum = aiv_num)
         
         return output1, afdmetadata
+
+def cam_send_attn_output_impl(hidden_states: torch.Tensor,
+                              topk_weights: torch.Tensor,
+                              topk_idx: torch.Tensor,
+                              hccl_comm_name: str,
+                              hccl_comm_name2: str,
+                              rank: int,
+                              ffn_size: int,
+                              attn_size: int) -> torch.Tensor:
+    ubatch_idx = get_forward_context().ubatch_idx
+    if get_forward_context().cam_afdconnector_data is None:
+        cam_afdconnector_data = CAMAFDConnectorMetadata(
+            moe_expert_num = 64,
+            shared_expert_num = 0,
+            scale = None,
+            handle = None,
+            quant_mode = 0,
+            aiv_num = 48,
+            batch_size = 20,
+            h = 2048,
+            k = 8
+        )
+        get_forward_context().cam_afdconnector_data = cam_afdconnector_data
+
+    cam_metadata = get_forward_context().cam_afdconnector_data
+    batch_size = cam_metadata.batch_size
+    h = cam_metadata.h
+    k = cam_metadata.k
+    moe_expert_num = cam_metadata.moe_expert_num
+    shared_expert_num = cam_metadata.shared_expert_num
+    quant_mode = cam_metadata.quant_mode
+    aiv_num = cam_metadata.aiv_num
+    expandXOutDType = torch.tensor([], dtype=torch.bfloat16 if not quant_mode else torch.int8, device='npu')
+
+    handle_out = torch_npu.cam_a2e(expandX = hidden_states, expertIds = topk_idx,
+                        scales = topk_weights, commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+                        expandXOutDType = expandXOutDType,
+                        commId = 0, batchSize = batch_size, hiddenSize = h, topk = k,
+                        expertRankSize = ffn_size, attentionRankSize = attn_size,
+                        sharedExpertNum = shared_expert_num,
+                        totalExpertNum = moe_expert_num + shared_expert_num,
+                        rank = rank,
+                        loadBalancingRankNum=1, loadBalancingThreshold=0, dynamicQuant = quant_mode,
+                        groupEp = hccl_comm_name2 if ubatch_idx == 1 else hccl_comm_name,
+                        aivNum = aiv_num)
+    hidden_states1, dynamic_scales, expandIdx, expertTokenNums, epRecvCounts, \
+        simulateExpertIds, simulateExpertScales, attenBatchSize = handle_out[0:8]
+    handle = [simulateExpertIds, simulateExpertScales, expandIdx, epRecvCounts, attenBatchSize]
+    cam_metadata.handle = handle
+    get_forward_context().cam_afdconnector_data = cam_metadata
+    return hidden_states
+
+def cam_send_attn_output_fake_impl(hidden_states: torch.Tensor,
+                                    topk_weights: torch.Tensor,
+                                    topk_idx: torch.Tensor,
+                                    hccl_comm_name: str,
+                                    hccl_comm_name2: str,
+                                    rank: int,
+                                    ffn_size: int,
+                                    attn_size: int) -> torch.Tensor:
+    return hidden_states
+
+def cam_recv_ffn_output_impl(hidden_states: torch.Tensor,
+                              hccl_comm_name: str,
+                              hccl_comm_name2: str,
+                              rank: int,
+                              ffn_size: int,
+                              attn_size: int) -> torch.Tensor:
+    cam_metadata = get_forward_context().cam_afdconnector_data
+    assert cam_metadata is not None, "cam_metadata is None"
+    ubatch_idx = get_forward_context().ubatch_idx
+    batch_size = cam_metadata.batch_size
+    h = cam_metadata.h
+    k = cam_metadata.k
+    moe_expert_num = cam_metadata.moe_expert_num
+    shared_expert_num = cam_metadata.shared_expert_num
+    aiv_num = cam_metadata.aiv_num
+    handle = cam_metadata.handle
+    
+    output2 = torch_npu.cam_e2a(expandXOut = hidden_states, simulateExpertIds = handle[0],
+                        simulateExpertScales = handle[1], expandIdx = handle[2],
+                        epRecvCounts = handle[3],
+                        commArgs = torch.tensor([], dtype=torch.float16, device='npu'),
+                        attenBatchSize = handle[4],
+                        commId = 0,
+                        batchSize = batch_size, hiddenSize = h, topk = k,
+                        expertRankSize = ffn_size, attentionRankSize = attn_size,
+                        sharedExpertNum = shared_expert_num, totalExpertNum = moe_expert_num + shared_expert_num,
+                        rank = rank,
+                        loadBalancingRankNum=1, loadBalancingThreshold=0,
+                        groupEp = hccl_comm_name2 if ubatch_idx == 1 else hccl_comm_name,
+                        aivNum = aiv_num)
+
+    return output2
+
+def cam_recv_ffn_output_fake_impl(hidden_states: torch.Tensor,
+                                  hccl_comm_name: str,
+                                  hccl_comm_name2: str,
+                                  rank: int,
+                                  ffn_size: int,
+                                  attn_size: int) -> torch.Tensor:
+    return hidden_states
+
+direct_register_custom_op(op_name="cam_send_attn_output",
+                          op_func=cam_send_attn_output_impl,
+                          fake_impl=cam_send_attn_output_fake_impl,
+                          mutates_args=[],
+                          dispatch_key="PrivateUse1")
+
+direct_register_custom_op(op_name="cam_recv_ffn_output",
+                          op_func=cam_recv_ffn_output_impl,
+                          fake_impl=cam_recv_ffn_output_fake_impl,
+                          mutates_args=[],
+                          dispatch_key="PrivateUse1")

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -258,6 +258,11 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         
         return output1, afdmetadata
     
+    def send_is_ubatch(self,is_ubatch):
+        dst = (self.process_group.rank_in_group + 1) % self.process_group.world_size
+        self.process_group.send_object(is_ubatch,dst)
+        
+    #TODO(yxj):to support inequal AF
     def send_metadata(self,data,dst,group):
         # Serialize object to tensor and get the size as well
         object_tensor = torch.frombuffer(pickle.dumps(data), dtype=torch.uint8)
@@ -274,7 +279,8 @@ class CAMM2NAFDConnector(AFDConnectorBase):
         torch.distributed.send(object_tensor,
                                 dst=dst,
                                 group=group)
-        
+    
+    #TODO(yxj):to support inequal AF
     def recv_metadata(self):
         src = self.p2p_rank % self.min_size
         print(f'src in recv_metadata is {src}')

--- a/vllm_ascend/ops/moe/moe_mlp.py
+++ b/vllm_ascend/ops/moe/moe_mlp.py
@@ -23,8 +23,8 @@ from vllm.forward_context import get_forward_context
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.utils import dispose_tensor, is_310p
-import umdk_cam_op_lib
-from umdk_cam_operator import dispatch_gmm_combine_decode
+
+
 
 
 def cumsum_group_list(group_list: torch.Tensor,
@@ -273,6 +273,8 @@ def fused_experts(
         ep_rank_id: int,
         moe_expert_num:int,
     ):
+    import umdk_cam_op_lib
+    from umdk_cam_operator import dispatch_gmm_combine_decode
     output, _ = torch.ops.umdk_cam_op_lib.dispatch_gmm_combine_decode(
         x=hidden_states,
         expert_ids=topk_ids,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1357,6 +1357,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         dst = (self.afd_connector.process_group.rank_in_group + 1) % self.afd_connector.process_group.world_size
         is_ubatch = True if ubatch_slices else False
         self.afd_connector.process_group.send_object(is_ubatch,dst)
+        # is_ubatch = True if ubatch_slices else False
+        # dst_list = self.afd_connector.dst_list
+        # if self.afd_connector.ffn_size <= self.afd_connector.rank < self.afd_connector.ffn_size + self.afd_connector.min_size:
+        #     for dst in dst_list:
+        #         self.afd_connector.send_metadata(metadata,dst,self.afd_connector.p2p_pg)
         print(f'send is_ubatch in prepare input is {is_ubatch}')
         
         
@@ -2620,7 +2625,12 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         dst = (self.afd_connector.process_group.rank_in_group + 1) % self.afd_connector.process_group.world_size
         is_ubatch = True if ubatch_slices else False
         self.afd_connector.process_group.send_object(is_ubatch,dst)
-        print(f'send is_ubatch in dummy_run is {is_ubatch}',flush=True)
+        # is_ubatch = True if ubatch_slices else False
+        # dst_list = self.afd_connector.dst_list
+        # if self.afd_connector.ffn_size <= self.afd_connector.rank < self.afd_connector.ffn_size + self.afd_connector.min_size:
+        #     for dst in dst_list:
+        #         self.afd_connector.send_metadata(is_ubatch,dst,self.afd_connector.p2p_pg)
+        print(f'send is_ubatch in prepare input is {is_ubatch}')
         
         num_tokens_after_padding = num_tokens
         if num_tokens_across_dp is not None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1353,11 +1353,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                 uniform_decode=uniform_decode,
                 num_scheduled_tokens_per_request=num_scheduled_tokens,
             )
-        # # send is_ubatch to ffn side
-        # dst = (self.afd_connector.process_group.rank_in_group + 1) % self.afd_connector.process_group.world_size
-        # is_ubatch = True if ubatch_slices else False
-        # self.afd_connector.process_group.send_object(is_ubatch,dst)
-        # print(f'send is_ubatch in prepare input is {is_ubatch}')
+        # send is_ubatch to ffn side
+        dst = (self.afd_connector.process_group.rank_in_group + 1) % self.afd_connector.process_group.world_size
+        is_ubatch = True if ubatch_slices else False
+        self.afd_connector.process_group.send_object(is_ubatch,dst)
+        print(f'send is_ubatch in prepare input is {is_ubatch}')
         
         
 
@@ -2616,11 +2616,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             # if aclgraph_capture_sizes:
             #     update_graph_params(aclgraph_capture_sizes)
         logger.info(f"dummy_run, ubatch_slices: {ubatch_slices}")
-        # # send is_ubatch to ffn side
-        # dst = (self.afd_connector.process_group.rank_in_group + 1) % self.afd_connector.process_group.world_size
-        # is_ubatch = True if ubatch_slices else False
-        # self.afd_connector.process_group.send_object(is_ubatch,dst)
-        # print(f'send is_ubatch in dummy_run is {is_ubatch}',flush=True)
+        # send is_ubatch to ffn side
+        dst = (self.afd_connector.process_group.rank_in_group + 1) % self.afd_connector.process_group.world_size
+        is_ubatch = True if ubatch_slices else False
+        self.afd_connector.process_group.send_object(is_ubatch,dst)
+        print(f'send is_ubatch in dummy_run is {is_ubatch}',flush=True)
         
         num_tokens_after_padding = num_tokens
         if num_tokens_across_dp is not None:

--- a/vllm_ascend/worker/npu_ffn_model_runner_v1.py
+++ b/vllm_ascend/worker/npu_ffn_model_runner_v1.py
@@ -135,7 +135,7 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
 
         
     @torch.inference_mode()
-    def execute_model(self, scheduler_output=None, intermediate_tensors=None,is_ubatch:bool=False):
+    def execute_model(self, scheduler_output=None, intermediate_tensors=None, is_ubatch:bool=False):
         """Execute FFN computation for a single request"""
         # self.prof.step()
         current_layer_idx = self._get_current_layer_idx()

--- a/vllm_ascend/worker/npu_ffn_model_runner_v1.py
+++ b/vllm_ascend/worker/npu_ffn_model_runner_v1.py
@@ -63,14 +63,14 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
         self._counter = 0
 
         # Initialize ACL graph support
-        self.cudagraph_batch_sizes = list(
+        self.aclgraph_batch_sizes = list(
             reversed(
                 self.vllm_config.compilation_config.cudagraph_capture_sizes))
-        # self.aclgraph_batch_sizes = list(
-        #     reversed(self.compilation_config.cudagraph_capture_sizes))
         
         # Storage for captured graphs
         self._acl_graphs_full: dict[int, torch.npu.NPUGraph] = {
+        }  # {num_tokens: ACLGraph}
+        self._acl_graphs_ubatch_full: dict[int, torch.npu.NPUGraph] = {
         }  # {num_tokens: ACLGraph}
         self.graph_pool = None
 
@@ -95,6 +95,11 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
         self.n_routed_experts = self.model_config.hf_config.n_routed_experts
         self.hidden_size = self.model_config.hf_config.hidden_size
         print(f'self.topk is {self.topk}')
+
+        # TODO(jcz): 对于ffn eager模式下_current_num_ubatches逻辑和layer_idx的计算逻辑需要优化
+        #            这里的2是hardcode，需要根据实际情况调整，初始化的时候目前暂时需要初始化成dummy run跑的batch_size
+        self._current_num_ubatches = self.afd_config.num_afd_stages
+        self.is_ubatch = False
         
         # self.profiler
         # import os
@@ -122,47 +127,59 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
         self.connector.init_afd_connector()
 
     def _get_current_layer_idx(self) -> int:
-        return (self._counter //
-                self.afd_config.num_afd_stages) % self.num_layers
+        return (self._counter // self._current_num_ubatches) % self.num_layers
     
-    def profile_run(self):
-        self._dummy_run(self.max_num_tokens)
+    def profile_run(self,is_ubatch:bool=False):
+        print(f'yxj is_ubatch in profile_run is {is_ubatch}')
+        self._dummy_run(self.max_num_tokens,is_ubatch=is_ubatch)
 
         
     @torch.inference_mode()
-    def execute_model(self, scheduler_output=None, intermediate_tensors=None):
+    def execute_model(self, scheduler_output=None, intermediate_tensors=None,is_ubatch:bool=False):
         """Execute FFN computation for a single request"""
-        # scheduler_output and intermediate_tensors are unused in FFN server
-        # mode
         # self.prof.step()
         current_layer_idx = self._get_current_layer_idx()
         try:
             # skip dense layer
-            if current_layer_idx < self.first_k_dense_replace:
-                return
-            if current_layer_idx >= self.num_hidden_layers:
-                return
-            torch.npu.synchronize()
-            if self.use_aclgraph:
+            # if current_layer_idx < self.first_k_dense_replace:
+            #     return
+            
+            if self.use_aclgraph and not is_ubatch:
+                #mock
+                # self._ffn_forward(aclgraph_runtime_mode=CUDAGraphMode.NONE,is_ubatch=is_ubatch)
+                # self._dummy_run(num_tokens,
+                #                 aclgraph_runtime_mode=CUDAGraphMode.NONE,
+                #                 force_attention=force_attention,
+                #                 uniform_decode=uniform_decode,
+                #                 is_ubatch=is_ubatch)
+                # # TODO(yxj):ffn图模式会直接replay，应该设计成ffn收到attn消息才开始replay
                 # replay
                 if self.connector_name == "camm2nconnector":
-                    max_num_tokens = self.max_num_tokens * self.attn_size * (self.n_routed_experts // self.ffn_size)
-                    print(f'[CAM FFN Replay] Calculated max_num_tokens={max_num_tokens}')
+                    max_num_tokens = self.max_num_tokens * self.attn_size * (self.n_routed_experts // self.ffn_size) * (self.attn_size // self.ffn_size)
                 elif self.connector_name == "camp2pconnector":
                     max_num_tokens = self.max_num_tokens
                 else:
                     max_num_tokens = self.max_num_tokens * self.topk * self.attn_size
                 acl_graph_info = self._acl_graphs_full.get(max_num_tokens)
-                if acl_graph_info is None:
-                    raise ValueError(
-                        f"ACL graph not found for max_num_tokens={max_num_tokens}. "
-                        f"Available keys: {list(self._acl_graphs_full.keys())}, "
-                        f"connector={self.connector_name}, attn_size={self.attn_size}, ffn_size={self.ffn_size}")
                 graph = acl_graph_info['graph']
                 graph.replay()
                 self.replay_cnt += 1
-                print(f"ffn replay,replay_cnt is {self.replay_cnt}")
+                print(f"ffn replay,replay_cnt is {self.replay_cnt}",flush=True)
                 return
+            elif self.use_aclgraph and is_ubatch:
+                # TODO(yxj):ffn图模式会直接replay，应该设计成ffn收到attn消息才开始replay
+                # replay
+                if self.connector_name == "camconnector":
+                    max_num_tokens = self.max_num_tokens * self.attn_size * (self.n_routed_experts // self.ffn_size) * (self.attn_size // self.ffn_size)
+                else:
+                    max_num_tokens = self.max_num_tokens * self.topk * self.attn_size
+                acl_graph_info = self._acl_graphs_ubatch_full.get(max_num_tokens)
+                graph = acl_graph_info['graph']
+                graph.replay()
+                self.replay_cnt += 1
+                print(f"ffn replay,replay_cnt is {self.replay_cnt}",flush=True)
+                return
+                
             if self.connector_name == "m2nconnector":
                 # TODO metadata
                 m2n_afdconnector_data = M2NAFDConnectorMetadata()
@@ -191,7 +208,8 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                     h = self.hidden_size,
                     k = self.topk
                 )
-                output1,afdConnectorMetadata = self.connector.recv_attn_output(cam_afdconnector_data)
+                output1,afdConnectorMetadata = self.connector.recv_attn_output(cam_afdconnector_data, self._counter % self._current_num_ubatches)
+                self._current_num_ubatches = afdConnectorMetadata.num_ubatches
                 hidden_states, dynamic_scales, expandIdx, expertTokenNums, epRecvCounts, simulateExpertIds, simulateExpertScales, attenBatchSize = output1[0:8]
                 group_list = expertTokenNums.to(torch.int64)
                 topk_weights = simulateExpertScales
@@ -212,6 +230,8 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                 topk_weights = simulateExpertScales
                 topk_ids = simulateExpertIds
                 x_active_mask = xActiveMaskOut
+                print(f'recv_attn_output success ,layer id is {current_layer_idx}')
+                print(f'hidden_states shape is {hidden_states.shape},dtype is {hidden_states.dtype}')
             elif self.connector_name == "p2pconnector":
                 hidden_states,router_logits,topk_weights, topk_ids, row_idx, afdConnectorMetadata = self.connector.recv_attn_output()
                 if afdConnectorMetadata is not None and afdConnectorMetadata.recv_handle_list is not None:
@@ -231,102 +251,47 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                 max_num_tokens = self.max_num_tokens * self.attn_size * (cam_afdconnector_data.moe_expert_num // self.ffn_size) * (self.attn_size // self.ffn_size)
             else:
                 max_num_tokens = self.max_num_tokens * self.topk * self.attn_size # 64
-            self.cudagraph_batch_sizes.append(max_num_tokens)
+            self.aclgraph_batch_sizes.append(max_num_tokens)
             num_tokens = hidden_states.shape[0]
-            acl_graph_info = self._find_cuda_graph(current_layer_idx,
-                                                    num_tokens)
-
+            print(f'num_tokens  is {num_tokens}')
             
-            print(f'acl_graph_info is {acl_graph_info}')
-            print(f'current_layer_idx is {current_layer_idx},num_tokens is {max_num_tokens}')
-            print(f'self._forword_cnt is {self._forword_cnt},num_tokens is {max_num_tokens}')
-           
-            if acl_graph_info is not None:
-                # Use captured ACL graph for computation
-                with set_ascend_forward_context(
-                        attn_metadata=None,
-                        vllm_config=self.vllm_config,
-                        reserved_mc2_mask=self.reserved_mc2_mask,
-                        # batch_descriptor=batch_descriptor,
-                        # aclgraph_runtime_mode=aclgraph_runtime_mode,
-                        prefetch_stream=self.prefetch_stream,
-                        model_instance=self.model):
-                    if self.connector_name == "m2nconnector":
-                        # 未combine hidden
-                        # TODO(yxj)：图模式
-                        rank_ffn_output = self._execute_with_acl_graph(
-                            acl_graph_info = acl_graph_info,
-                            hidden_states=hidden_states,
-                            group_list=group_list,
-                            dynamic_scales=dynamic_scales,
-                            topk_weights=topk_weights,
-                            current_layer_idx=current_layer_idx)
-                    elif self.connector_name == "camm2nconnector":
-                        # 未combine hidden
-                        rank_ffn_output = self._execute_with_acl_graph(
-                            acl_graph_info = acl_graph_info,
-                            hidden_states=hidden_states,
-                            group_list=group_list,
-                            dynamic_scales=dynamic_scales,
-                            topk_weights=topk_weights,
-                            current_layer_idx=current_layer_idx)
-                    elif self.connector_name == "camp2pconnector":
-                        # 未combine hidden
-                        rank_ffn_output = self._execute_with_acl_graph(
-                            acl_graph_info = acl_graph_info,
-                            hidden_states=hidden_states,
-                            topk_ids=topk_ids,
-                            x_active_mask=x_active_mask,
-                            topk_weights=topk_weights,
-                            current_layer_idx=current_layer_idx,
-                            cam_p2p_ep_name=cam_p2p_ep_name)
-                    else:
-                        rank_ffn_output = self._execute_with_acl_graph(
-                            acl_graph_info = acl_graph_info,
-                            hidden_states = hidden_states,
-                            router_logits = router_logits,
-                            current_layer_idx = current_layer_idx,
-                            topk_weights = topk_weights, 
-                            topk_ids = topk_ids,
-                            row_idx = row_idx,
-                            )
-            else:
-                # Fallback to eager mode
-                if afdConnectorMetadata is not None:
-                    ffn_need_forward_data = afdConnectorMetadata.ffn_need_forward_data
-                    with_prefill = ffn_need_forward_data.with_prefill
-                    moe_comm_type = ffn_need_forward_data.moe_comm_type
-                    num_input_tokens = ffn_need_forward_data.num_input_tokens
-                    total_num_scheduled_tokens = ffn_need_forward_data.total_num_scheduled_tokens
-                    current_layer_idx = afdConnectorMetadata.layer_idx
-                # test
-                with set_ascend_forward_context(
-                        attn_metadata=None,
-                        vllm_config=self.vllm_config,
-                        num_tokens=num_input_tokens,
-                        with_prefill=with_prefill,
-                        reserved_mc2_mask=self.reserved_mc2_mask,
-                        moe_comm_type=moe_comm_type,
-                        prefetch_stream=self.prefetch_stream,
-                        num_actual_tokens=total_num_scheduled_tokens,
-                        model_instance=self.model):
-                    if self.connector_name == "m2nconnector":
-                        # 未combine hidden
-                        rank_ffn_output = self._execute_eager_mode(
-                            hidden_states=hidden_states,
-                            group_list=group_list,
-                            dynamic_scales=dynamic_scales,
-                            topk_weights=topk_weights,
-                            current_layer_idx=current_layer_idx)
-                    elif self.connector_name == "camm2nconnector":
-                        # 未combine hidden
-                        rank_ffn_output = self._execute_eager_mode(
-                            hidden_states=hidden_states,
-                            group_list=group_list,
-                            dynamic_scales=dynamic_scales,
-                            topk_weights=topk_weights,
-                            current_layer_idx=current_layer_idx)
-                    elif self.connector_name == "camp2pconnector":
+            
+            # Fallback to eager mode
+            if afdConnectorMetadata is not None:
+                ffn_need_forward_data = afdConnectorMetadata.ffn_need_forward_data
+                with_prefill = ffn_need_forward_data.with_prefill
+                moe_comm_type = ffn_need_forward_data.moe_comm_type
+                num_input_tokens = ffn_need_forward_data.num_input_tokens
+                total_num_scheduled_tokens = ffn_need_forward_data.total_num_scheduled_tokens
+                current_layer_idx = afdConnectorMetadata.layer_idx
+            # test
+            with set_ascend_forward_context(
+                    attn_metadata=None,
+                    vllm_config=self.vllm_config,
+                    num_tokens=num_input_tokens,
+                    with_prefill=with_prefill,
+                    reserved_mc2_mask=self.reserved_mc2_mask,
+                    moe_comm_type=moe_comm_type,
+                    prefetch_stream=self.prefetch_stream,
+                    num_actual_tokens=total_num_scheduled_tokens,
+                    model_instance=self.model):
+                if self.connector_name == "m2nconnector":
+                    # 未combine hidden
+                    rank_ffn_output = self._execute_eager_mode(
+                        hidden_states=hidden_states,
+                        group_list=group_list,
+                        dynamic_scales=dynamic_scales,
+                        topk_weights=topk_weights,
+                        current_layer_idx=current_layer_idx)
+                elif self.connector_name == "camm2nconnector":
+                    # 未combine hidden
+                    rank_ffn_output = self._execute_eager_mode(
+                        hidden_states=hidden_states,
+                        group_list=group_list,
+                        dynamic_scales=dynamic_scales,
+                        topk_weights=topk_weights,
+                        current_layer_idx=current_layer_idx)
+                elif self.connector_name == "camp2pconnector":
                         # 未combine hidden
                         rank_ffn_output = self._execute_eager_mode(
                             hidden_states=hidden_states,
@@ -335,27 +300,27 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                             topk_weights=topk_weights,
                             current_layer_idx=current_layer_idx,
                             cam_p2p_ep_name=cam_p2p_ep_name)
-                    else:
-                        rank_ffn_output = self._execute_eager_mode(
-                            hidden_states = hidden_states,
-                            router_logits = router_logits,
-                            current_layer_idx = current_layer_idx,
-                            topk_weights = topk_weights, 
-                            topk_ids = topk_ids,
-                            row_idx = row_idx,
-                            )
+                else:
+                    rank_ffn_output = self._execute_eager_mode(
+                        hidden_states = hidden_states,
+                        router_logits = router_logits,
+                        current_layer_idx = current_layer_idx,
+                        topk_weights = topk_weights, 
+                        topk_ids = topk_ids,
+                        row_idx = row_idx,
+                        )
 
             if self.connector_name == "camm2nconnector":
                 handle = [simulateExpertIds, simulateExpertScales, expandIdx, epRecvCounts, attenBatchSize]
                 cam_afdconnector_data.handle = handle
-                self.connector.send_ffn_output(rank_ffn_output, cam_afdconnector_data)
+                self.connector.send_ffn_output(rank_ffn_output, cam_afdconnector_data, self._counter % self._current_num_ubatches)
             elif self.connector_name == "camp2pconnector":
                 handle = [attenBatchSize]
                 cam_afdconnector_data.handle = handle
                 self.connector.send_ffn_output(rank_ffn_output, cam_afdconnector_data)
             elif self.connector_name == "m2nconnector":
                 self.connector.send_ffn_output(rank_ffn_output, m2n_afdconnector_data)
-                print(f'send_ffn_output success ,layer id is {current_layer_idx}')
+                print(f'send_ffn_output success ,layer id is {current_layer_idx}',flush=True)
             else :
                 afdConnectorMetadata.recv_handle_list = None
                 self.connector.send_ffn_output(rank_ffn_output, afdConnectorMetadata)
@@ -366,8 +331,10 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             ) from e
         finally:
             self._counter += 1
+            # if (self._counter == self.num_layers *
+            #         self.afd_config.num_afd_stages):
             if (self._counter == self.num_layers *
-                    self.afd_config.num_afd_stages):
+                    self._current_num_ubatches):
                 self._counter = 0
                 self._forword_cnt += 1
         return None  # FFN server doesn't return ModelRunnerOutput
@@ -510,14 +477,14 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
     
 
     
-    def capture_model(self) -> int:
+    def capture_model(self,is_ubatch:bool=False) -> int:
         """Capture ACL graphs for FFN operations."""
         
         logger.debug("Starting ACL graph capture for FFN operations...")
         start_time = time.perf_counter()
         start_free_npu_memory = torch.npu.mem_get_info()[0]
         
-        self._capture_model()
+        self._capture_model(is_ubatch)
         
         end_time = time.perf_counter()
         end_free_npu_memory = torch.npu.mem_get_info()[0]
@@ -529,7 +496,7 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
 
         return npu_graph_size
 
-    def _capture_model(self):
+    def _capture_model(self,is_ubatch:bool=False):
         if self.graph_pool is None:
             self.graph_pool = current_platform.get_global_graph_pool()
         if not self.use_aclgraph:
@@ -557,13 +524,15 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             self._capture_aclgraphs(
                     compilation_cases=compilation_cases_decode,
                     aclgraph_runtime_mode=CUDAGraphMode.FULL,
-                    uniform_decode=True)
+                    uniform_decode=True,
+                    is_ubatch=is_ubatch)
            
         set_cudagraph_capturing_enabled(False)
         
     def _capture_aclgraphs(self, compilation_cases: list[int],
                            aclgraph_runtime_mode: CUDAGraphMode,
-                           uniform_decode: bool):
+                           uniform_decode: bool,
+                           is_ubatch:bool=False):
         assert aclgraph_runtime_mode != CUDAGraphMode.NONE and \
             aclgraph_runtime_mode in [CUDAGraphMode.FULL,
                                       CUDAGraphMode.PIECEWISE]
@@ -587,17 +556,27 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                 self._dummy_run(num_tokens,
                                 aclgraph_runtime_mode=CUDAGraphMode.NONE,
                                 force_attention=force_attention,
-                                uniform_decode=uniform_decode)
+                                uniform_decode=uniform_decode,
+                                is_ubatch=is_ubatch)
             self._dummy_run(num_tokens,
                             aclgraph_runtime_mode=CUDAGraphMode.FULL,
                             force_attention=force_attention,
-                            uniform_decode=uniform_decode)
+                            uniform_decode=uniform_decode,
+                            is_ubatch=is_ubatch)
     
     def _dummy_run(self, 
                    num_tokens: int = 1, 
                    aclgraph_runtime_mode: Optional[CUDAGraphMode] = None,
                    force_attention: bool = False,
-                   uniform_decode: bool = False,**kwargs):
+                   uniform_decode: bool = False,
+                   is_ubatch:bool=False,
+                   **kwargs):
+        
+        # recv self.is_ubatch form attn side
+        # src = (self.connector.process_group.rank_in_group - 1) % self.connector.process_group.world_size
+        # is_ubatch = self.connector.process_group.recv_object(src)
+        # print(f'yxj src in _dummy_run is {src}')
+        print(f'yxj is_ubatch in _dummy_run is {is_ubatch}')
         
         # only support eager mode and piecewise graph now
         assert aclgraph_runtime_mode is None or aclgraph_runtime_mode in {
@@ -624,19 +603,29 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             with torch.npu.graph(aclgraph, pool=self.graph_pool):
                 # compute_ffn_output
                 output = self._ffn_forward(batch_descriptor=batch_descriptor,
-                                  aclgraph_runtime_mode=aclgraph_runtime_mode)
+                                  aclgraph_runtime_mode=aclgraph_runtime_mode,
+                                  is_ubatch=is_ubatch)
             print(f'output shape is {output.shape}')
             # Store the captured graph with token count as key
-            self._acl_graphs_full[output.shape[0]] = {
-                'graph': aclgraph,
-                'input_hidden_states': output,
-                'output': output
-            }
-            print(f'self._acl_graphs_full is {self._acl_graphs_full}')
+            if is_ubatch:
+                self._acl_graphs_ubatch_full[output.shape[0]] = {
+                    'graph': aclgraph,
+                    'input_hidden_states': output,
+                    'output': output
+                }
+                print(f'self._acl_graphs_ubatch_full is {self._acl_graphs_ubatch_full}',flush=True)
+            else:
+                self._acl_graphs_full[output.shape[0]] = {
+                    'graph': aclgraph,
+                    'input_hidden_states': output,
+                    'output': output
+                }
+                print(f'self._acl_graphs_full is {self._acl_graphs_full}',flush=True)
         else:
             self._ffn_forward(batch_descriptor=batch_descriptor,
-                                  aclgraph_runtime_mode=aclgraph_runtime_mode) 
-            print("finsh capture warm_up")
+                                  aclgraph_runtime_mode=aclgraph_runtime_mode,
+                                  is_ubatch=is_ubatch) 
+            print("finsh capture warm_up or prefile run",flush=True)
         print(f'self.dummy_run_call_cnt is {self.dummy_run_call_cnt}')
         self.dummy_run_call_cnt += 1
 
@@ -669,45 +658,51 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
 
 
     def _ffn_forward(self,
-                     batch_descriptor,
-                     aclgraph_runtime_mode: Optional[CUDAGraphMode] = None,):
-        # mock self.model
+                     batch_descriptor=None,
+                     aclgraph_runtime_mode: Optional[CUDAGraphMode] = None,
+                     is_ubatch:bool=False):
+        print(f'yxj is_ubatch in _ffn_forward is {is_ubatch}',flush=True)
+        ubatch_nums = 2
+        cur_num_stages = 0
         for layer_idx in range(self.first_k_dense_replace,self.num_layers):
-            # recv
-            if self.connector_name == "m2nconnector":
-                # TODO metadata
-                m2n_afdconnector_data = M2NAFDConnectorMetadata()
-                hidden_states, dynamic_scales, group_list, topk_weights, afdConnectorMetadata = \
-                self._build_and_recv_m2n_afdconnector(
-                    m2n_afdconnector_data=m2n_afdconnector_data,
-                    quant_mode= 0,
-                    expand_x_type = torch.bfloat16,
-                    n_routed_experts=self.n_routed_experts,
-                    hidden_size=self.hidden_size,
-                    topk=self.topk,
-                    expert_token_nums_type=0,
-                    attn_size=self.attn_size,
-                    max_num_tokens=self.max_num_tokens,
+            for ubatch_idx in range(ubatch_nums):
+                # recv
+                if self.connector_name == "m2nconnector":
+                    hidden_states, dynamic_scales, group_list, topk_weights, afdConnectorMetadata = \
+                        self._build_and_recv_m2n_afdconnector(
+                        m2n_afdconnector_data=m2n_afdconnector_data,
+                        quant_mode= 0,
+                        expand_x_type = torch.bfloat16,
+                        n_routed_experts=self.n_routed_experts,
+                        hidden_size=self.hidden_size,
+                        topk=self.topk,
+                        expert_token_nums_type=0,
+                        attn_size=self.attn_size,
+                        max_num_tokens=self.max_num_tokens,
+                        )
+                    # [64,2048]
+                    hidden_states, dynamic_scales, group_list, handle, topk_weights, afdConnectorMetadata = self.connector.recv_attn_output(m2n_afdconnector_data)
+                    print(f'recv_attn_output success ,layer id is {layer_idx},ubatch_idx is {ubatch_idx}',flush=True)
+                    m2n_afdconnector_data.handle = handle
+                    m2n_afdconnector_data.topk_weights = topk_weights
+                elif self.connector_name == "camm2nconnector":
+                    cam_afdconnector_data = CAMM2NAFDConnectorMetadata(
+                        moe_expert_num = self.n_routed_experts,
+                        shared_expert_num = 0,
+                        scale = None,
+                        handle = None,
+                        quant_mode = 0,
+                        aiv_num = 48,
+                        batch_size = self.max_num_tokens,
+                        h = self.hidden_size,
+                        k = self.topk
                     )
-
-            elif self.connector_name == "camm2nconnector":
-                cam_afdconnector_data = CAMM2NAFDConnectorMetadata(
-                    moe_expert_num = self.n_routed_experts,
-                    shared_expert_num = 0,
-                    scale = None,
-                    handle = None,
-                    quant_mode = 0,
-                    aiv_num = 48,
-                    batch_size = self.max_num_tokens,
-                    h = self.hidden_size,
-                    k = self.topk
-                )
-                output1,afdConnectorMetadata = self.connector.recv_attn_output(cam_afdconnector_data)
-                hidden_states, dynamic_scales, expandIdx, expertTokenNums, epRecvCounts, simulateExpertIds, simulateExpertScales, attenBatchSize = output1[0:8]
-                group_list = expertTokenNums.to(torch.int64)
-                topk_weights = simulateExpertScales
-                # compute
-            elif self.connector_name == "camp2pconnector":
+                    output1, afdConnectorMetadata = self.connector.recv_attn_output(cam_afdconnector_data, cur_num_stages)
+                    hidden_states, dynamic_scales, expandIdx, expertTokenNums, epRecvCounts, simulateExpertIds, simulateExpertScales, attenBatchSize = output1[0:8]
+                    group_list = expertTokenNums.to(torch.int64)
+                    topk_weights = simulateExpertScales
+                    print(f'cam recv_attn_output success ,layer id is {layer_idx},ubatch_idx is {ubatch_idx}',flush=True)
+                elif self.connector_name == "camp2pconnector":
                 cam_afdconnector_data = CAMP2PAFDConnectorMetadata(
                     moe_expert_num = self.n_routed_experts,
                     shared_expert_num = 0,
@@ -725,14 +720,14 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                 topk_ids = simulateExpertIds
                 x_active_mask = xActiveMaskOut
             with set_ascend_forward_context(
-                    attn_metadata=None,
-                    vllm_config=self.vllm_config,
-                    reserved_mc2_mask=self.reserved_mc2_mask,
-                    batch_descriptor=batch_descriptor,
-                    aclgraph_runtime_mode=aclgraph_runtime_mode,
-                    prefetch_stream=self.prefetch_stream,
-                    model_instance=self.model):
-                if self.connector_name == "camp2pconnector":
+                        attn_metadata=None,
+                        vllm_config=self.vllm_config,
+                        reserved_mc2_mask=self.reserved_mc2_mask,
+                        batch_descriptor=batch_descriptor,
+                        aclgraph_runtime_mode=aclgraph_runtime_mode,
+                        prefetch_stream=self.prefetch_stream,
+                        model_instance=self.model):
+                    if self.connector_name == "camp2pconnector":
                     rank_ffn_output = self._run_ffn_computation(hidden_states = hidden_states,
                                                 layer_idx=layer_idx,
                                                 capture_mode=True,
@@ -743,24 +738,28 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                                                 )
                 else:
                     rank_ffn_output = self._run_ffn_computation(hidden_states = hidden_states,
-                                                layer_idx=layer_idx,
-                                                capture_mode=True,
-                                                group_list=group_list,
-                                                dynamic_scales=dynamic_scales,
-                                                topk_weights=topk_weights
-                                                )
+                                                     layer_idx=layer_idx,
+                                                     capture_mode=True,
+                                                     group_list=group_list,
+                                                    dynamic_scales=dynamic_scales,
+                                                    topk_weights=topk_weights
+                                                 )
                 # send
                 if self.connector_name == "m2nconnector":
                     self.connector.send_ffn_output(rank_ffn_output, m2n_afdconnector_data)
+                    print(f'send_ffn_output success ,layer id is {layer_idx},ubatch_idx is {ubatch_idx}',flush=True)
                 elif self.connector_name == "camm2nconnector":
                     handle = [simulateExpertIds, simulateExpertScales, expandIdx, epRecvCounts, attenBatchSize]
                     cam_afdconnector_data.handle = handle
-                    self.connector.send_ffn_output(rank_ffn_output, cam_afdconnector_data)
+                    self.connector.send_ffn_output(rank_ffn_output, cam_afdconnector_data, cur_num_stages)
                 elif self.connector_name == "camp2pconnector":
                     handle = [attenBatchSize]
                     cam_afdconnector_data.handle = handle
                     self.connector.send_ffn_output(rank_ffn_output, cam_afdconnector_data)
-                # print(f'send_ffn_output success ,layer id is {layer_idx}')
+                    print(f'cam send_ffn_output success ,layer id is {layer_idx},ubatch_idx is {ubatch_idx}',flush=True)
+                # 如果切分，则更新cur_num_stages
+                if is_ubatch:
+                    cur_num_stages ^= 1
         return rank_ffn_output
   
         
@@ -1059,7 +1058,7 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
 
         # Find the minimum capture size that can handle num_tokens for this
         # layer
-        for capture_size in self.cudagraph_batch_sizes:
+        for capture_size in self.aclgraph_batch_sizes:
             if num_tokens <= capture_size:
                 return self._acl_graphs.get((layer_idx, capture_size))
         return None

--- a/vllm_ascend/worker/npu_ffn_model_runner_v1.py
+++ b/vllm_ascend/worker/npu_ffn_model_runner_v1.py
@@ -145,8 +145,9 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             #     return
             
             if self.use_aclgraph and not is_ubatch:
-                # mock
+                # TODO(yxj):use _acl_graphs_full replay
                 self._ffn_forward(aclgraph_runtime_mode=CUDAGraphMode.NONE,is_ubatch=is_ubatch)
+                self.replay_cnt += 1
                 print(f"ffn replay,replay_cnt is {self.replay_cnt}",flush=True)
                 return
             elif self.use_aclgraph and is_ubatch:

--- a/vllm_ascend/worker/npu_ubatch_wrapper.py
+++ b/vllm_ascend/worker/npu_ubatch_wrapper.py
@@ -348,7 +348,7 @@ class UBatchWrapper:
         ubatch_slices = forward_context.ubatch_slices
         aclgraph_runtime_mode = forward_context.cudagraph_runtime_mode
         afd_metadata = forward_context.afd_metadata
-
+        print(f"__call__ 1 ubatch_slices is {ubatch_slices} aclgraph_runtime_mode:{aclgraph_runtime_mode}")
         # If there's no ubatching, just run the runnable object
         if ubatch_slices is None:
 
@@ -406,6 +406,7 @@ class UBatchWrapper:
             print(f"jcz __call__ 3 num_tokens is {num_tokens} aclgraphs is {self.aclgraphs}")
             aclgraph_metadata = self.aclgraphs[num_tokens]
             aclgraph_metadata.aclgraph.replay()
+            print("UBatchWrapper replay")
             return aclgraph_metadata.outputs
         else:
             print(f"jcz __call__ 4 num_tokens is {num_tokens}")

--- a/vllm_ascend/worker/npu_ubatch_wrapper.py
+++ b/vllm_ascend/worker/npu_ubatch_wrapper.py
@@ -296,6 +296,7 @@ class UBatchWrapper:
             forward_context.cudagraph_runtime_mode = aclgraph_runtime_mode
             forward_context.batch_descriptor = batch_descriptor
             forward_context.afd_metadata = afd_metadata
+            forward_context.num_ubatches = len(ubatch_slices)
             forward_contexts.append(forward_context)
 
         ubatch_ctxs = make_ubatch_contexts(

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -251,6 +251,7 @@ class NPUWorker(WorkerBase):
             try:
                 while not self._ffn_shutdown_event.is_set():
                     # Execute FFN computation
+                    # is_ubatch = self.model_runner.connector.recv_metadata()
                     is_ubatch = self.recv_is_ubatch()
                     self.model_runner.execute_model(scheduler_output=None,is_ubatch=is_ubatch)
             except Exception as e:

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -211,7 +211,7 @@ class NPUWorker(WorkerBase):
             return
         if not self.model_config.enforce_eager:
             print("start to ffn profile_run  ")
-            self.model_runner.profile_run()
+            self.model_runner.profile_run(is_ubatch=True)
             # self.model_runner.initialize_afd_connector()
             print("finsh  ffn profile_run  ")
             print("start  ffn compile_or_warm_up_model  ")
@@ -224,10 +224,10 @@ class NPUWorker(WorkerBase):
             ]
             for size in sorted(warmup_sizes, reverse=True):
                 logger.info("Compile and warming up model for size %d", size)
-                self.model_runner._dummy_run(size)
+                self.model_runner._dummy_run(size, is_ubatch=True)
             print("finsh  ffn compile_or_warm_up_model  ")
             print("start to capture ffn capture_model")
-            self.model_runner.capture_model()
+            self.model_runner.capture_model(is_ubatch=True)
             # self.model_runner.initialize_afd_connector()
             print("finsh  capture ffn capture_model")
         if self.profiler:

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -239,39 +239,40 @@ class NPUWorker(WorkerBase):
             print(self.profiler.key_averages().table(
                 sort_by="self_cuda_time_total"))
 
-        # import threading
-        # self._ffn_shutdown_event = threading.Event()
+        import threading
+        self._ffn_shutdown_event = threading.Event()
 
-        # def ffn_worker_loop():
-        #     # Set NPU device for this thread (thread-local context)
-        #     device = torch.device(f"npu:{self.local_rank}")
-        #     NPUPlatform.set_device(device)
-        #     logger.info("FFN worker loop started")
+        def ffn_worker_loop():
+            # Set NPU device for this thread (thread-local context)
+            device = torch.device(f"npu:{self.local_rank}")
+            NPUPlatform.set_device(device)
+            logger.info("FFN worker loop started")
 
-        #     try:
-        #         while not self._ffn_shutdown_event.is_set():
-        #             # Execute FFN computation
-        #             self.model_runner.execute_model(scheduler_output=None)
-        #     except Exception as e:
-        #         logger.error("FFN worker loop error: %s", e)
-        #         raise
+            try:
+                while not self._ffn_shutdown_event.is_set():
+                    # Execute FFN computation
+                    is_ubatch = self.recv_is_ubatch()
+                    self.model_runner.execute_model(scheduler_output=None,is_ubatch=is_ubatch)
+            except Exception as e:
+                logger.error("FFN worker loop error: %s", e)
+                raise
 
-        # self._ffn_thread = threading.Thread(target=ffn_worker_loop,
-        #                                     daemon=True)
-        # self._ffn_thread.start()
-        device = torch.device(f"npu:{self.local_rank}")
-        NPUPlatform.set_device(device)
-        cnt = 0
-        while True:
-            # 计算源rank
-            rank = self.model_runner.connector.process_group.rank_in_group
-            world_size = self.model_runner.connector.process_group.world_size
-            src = (rank - 1) % world_size
-            print(f"[主线程] 等待接收...",flush=True)
-            # 阻塞接收
-            is_ubatch = self.model_runner.connector.process_group.recv_object(src)
-            print(f"is_ubatch in start_ffn_server_loop is {is_ubatch},self.local_rank is {self.local_rank}",flush=True)
-            self.model_runner.execute_model(is_ubatch=is_ubatch)
+        self._ffn_thread = threading.Thread(target=ffn_worker_loop,
+                                            daemon=True)
+        self._ffn_thread.start()
+        # device = torch.device(f"npu:{self.local_rank}")
+        # NPUPlatform.set_device(device)
+        # cnt = 0
+        # while True:
+        #     # 计算源rank
+        #     rank = self.model_runner.connector.process_group.rank_in_group
+        #     world_size = self.model_runner.connector.process_group.world_size
+        #     src = (rank - 1) % world_size
+        #     print(f"[主线程] 等待接收...",flush=True)
+        #     # 阻塞接收
+        #     is_ubatch = self.model_runner.connector.process_group.recv_object(src)
+        #     print(f"is_ubatch in start_ffn_server_loop is {is_ubatch},self.local_rank is {self.local_rank}",flush=True)
+        #     self.model_runner.execute_model(is_ubatch=is_ubatch)
         logger.info("FFN server loop started in worker")
 
     def stop_ffn_server_loop(self) -> None:
@@ -517,3 +518,10 @@ class NPUWorker(WorkerBase):
 
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()
+    
+    def recv_is_ubatch(self):
+        rank = self.model_runner.connector.process_group.rank_in_group
+        world_size = self.model_runner.connector.process_group.world_size
+        src = (rank - 1) % world_size
+        is_ubatch = self.model_runner.connector.process_group.recv_object(src)
+        return is_ubatch


### PR DESCRIPTION

### What this PR does / why we need it?

DBO+aclgrph

### Does this PR introduce _any_ user-facing change?


### How was this patch tested?
```
#!/bin/bash
# python -m debugpy --listen 56306 --wait-for-client $(which vllm) serve /home/y00889327/DSV2LiteWeight \
# vllm serve /home/y00889327/DSV2LiteWeight \
# vllm serve /home/y00889327/DSV2LiteWeight \
#    --enable-dbo \
#    --dbo-prefill-token-threshold 12 \
#    --dbo-decode-token-threshold 2 \
# --tensor-parallel-size 2 \
# --data-parallel-size 2 \
# --enforce-eager \
# --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
#python -m debugpy --listen 56307 --wait-for-client -m vllm.entrypoints.afd_ffn_server /home/y00889327/DSV2LiteWeight\
# 用法说明
usage() {
    echo "用法: $0 [-a ATTENTION_DEVICES] [-f FFN_DEVICES] [-h]"
    echo "  参数:"
    echo "    -a ATTENTION_DEVICES  attention服务器使用的卡号（默认: 2,3）"
    echo "    -f FFN_DEVICES        ffn服务器使用的卡号（默认: 0,1）"
    echo "    -h                    显示帮助信息"
    echo ""
    echo "示例:"
    echo "  $0 -a 0,1 -f 2,3        使用卡0,1运行attention，卡2,3运行ffn"
    echo "  $0                      使用默认配置（卡2,3运行attention，卡0,1运行ffn）"
    exit 1
}

# 默认值
ATTENTION_DEVICES="14,15"
FFN_DEVICES="12,13"

# 解析命令行参数
while getopts "a:f:h" opt; do
    case $opt in
        a) ATTENTION_DEVICES="$OPTARG" ;;
        f) FFN_DEVICES="$OPTARG" ;;
        h) usage ;;
        \?) echo "无效选项: -$OPTARG" >&2; usage ;;
        :) echo "选项 -$OPTARG 需要参数" >&2; usage ;;
    esac
done

# 检查卡号是否冲突
check_device_conflict() {
    local dev1_arr=(${1//,/ })
    local dev2_arr=(${2//,/ })
    
    for dev1 in "${dev1_arr[@]}"; do
        for dev2 in "${dev2_arr[@]}"; do
            if [ "$dev1" = "$dev2" ]; then
                echo "错误: attention和ffn服务器使用了相同的卡号: $dev1"
                echo "请确保两个服务器使用不同的卡号"
                exit 1
            fi
        done
    done
}

# 检查卡号冲突
check_device_conflict "$ATTENTION_DEVICES" "$FFN_DEVICES"

echo "配置:"
echo "  Attention服务器卡号: $ATTENTION_DEVICES"
echo "  FFN服务器卡号: $FFN_DEVICES"
echo ""

# 设置公共环境变量
export HCCL_BUFFSIZE=4096
export VLLM_LOGGING_LEVEL=DEBUG

# 日志文件路径
LOG_DIR="/home/y00889327/workspace-afd/test-vllm-ascend"
ATTENTION_LOG="$LOG_DIR/attn_${ATTENTION_DEVICES//,/_}.log"
FFN_LOG="$LOG_DIR/ffn_${FFN_DEVICES//,/_}.log"

# 确保日志目录存在
mkdir -p "$LOG_DIR"

# 启动attention服务器
echo "=== 启动attention服务器（卡号: $ATTENTION_DEVICES）==="
export ASCEND_RT_VISIBLE_DEVICES="$ATTENTION_DEVICES"
nohup vllm serve /home/y00889327/DSV2LiteWeight \
    --data-parallel-size 2 \
    --max_num_batched_tokens 20 \
    --max_num_seqs 20 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
    --enable-dbo \
    --dbo-prefill-token-threshold 12 \
    --dbo-decode-token-threshold 2 \
    --port 8006 \
    --max-model-len 4096 \
    --afd-config '{"afd_connector":"camm2nconnector", "afd_role": "attention", "num_afd_stages":"2","afd_extra_config":{"afd_size":"2A2F"}, "compute_gate_on_attention": "True","afd_port":"29666"}' \
    > "$ATTENTION_LOG" 2>&1 &
ATTENTION_PID=$!

# 记录PID
echo "attention服务器PID: $ATTENTION_PID"
echo "日志文件: $ATTENTION_LOG"

# 启动ffn服务器
echo ""
echo "=== 启动ffn服务器（卡号: $FFN_DEVICES）==="
export ASCEND_RT_VISIBLE_DEVICES="$FFN_DEVICES"
nohup python -m vllm.entrypoints.afd_ffn_server /home/y00889327/DSV2LiteWeight\
    --tensor-parallel-size 2 \
    --enable_expert_parallel \
    --max_num_batched_tokens 20 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
    --enable-dbo \
    --dbo-prefill-token-threshold 12 \
    --dbo-decode-token-threshold 2 \
    --max_num_seqs 20 \
    --max-model-len 4096 \
    --afd-config '{"afd_connector":"camm2nconnector", "num_afd_stages":"2", "afd_role": "ffn", "afd_extra_config":{"afd_size":"2A2F"}, "compute_gate_on_attention": "True","afd_port":"29666"}' \
    > "$FFN_LOG" 2>&1 &
FFN_PID=$!

# 记录PID
echo "ffn服务器PID: $FFN_PID"
echo "日志文件: $FFN_LOG"

# 保存PID到文件，方便后续管理
PIDS_FILE="$LOG_DIR/server_pids_$(date +%Y%m%d_%H%M%S).txt"
echo "ATTENTION_PID=$ATTENTION_PID" > "$PIDS_FILE"
echo "FFN_PID=$FFN_PID" >> "$PIDS_FILE"
echo "ATTENTION_LOG=$ATTENTION_LOG" >> "$PIDS_FILE"
echo "FFN_LOG=$FFN_LOG" >> "$PIDS_FILE"
echo "ATTENTION_DEVICES=$ATTENTION_DEVICES" >> "$PIDS_FILE"
echo "FFN_DEVICES=$FFN_DEVICES" >> "$PIDS_FILE"

echo ""
echo "=== 服务器启动完成 ==="
echo "两个服务器已同时拉起并运行在后台"
echo "PID文件: $PIDS_FILE"
echo ""
echo "监控日志:"
echo "  tail -f $ATTENTION_LOG"
echo "  tail -f $FFN_LOG"
echo ""
echo "停止服务器:"
echo "  kill $ATTENTION_PID $FFN_PID"
echo "或使用停止脚本: $0 stop (如果实现了停止功能)"

# 提供一个简单的监控选项
read -p "是否打开实时日志监控? (y/n): " -n 1 -r
echo ""
if [[ $REPLY =~ ^[Yy]$ ]]; then
    echo "=== 实时日志监控（Ctrl+C退出监控，服务器继续运行）==="
    echo "注意: 按 Ctrl+C 只退出监控，服务器继续在后台运行"
    echo ""
    
    # 检查是否安装了multitail
    if command -v multitail &> /dev/null; then
        multitail -s 2 \
            -l "tail -f $ATTENTION_LOG" \
            -l "tail -f $FFN_LOG" \
            -cs attention -T "Attention Server ($ATTENTION_DEVICES)" \
            -cs ffn -T "FFN Server ($FFN_DEVICES)"
    else
        echo "ATTENTION 服务器日志 ($ATTENTION_DEVICES):"
        echo "FFN 服务器日志 ($FFN_DEVICES):"
        echo "----------------------------------------"
        # 使用简单的tail -f同时查看两个日志
        (tail -f "$ATTENTION_LOG" & tail -f "$FFN_LOG") | awk '/^==>/ {print "\033[32m" $0 "\033[0m"; next} {print}'
    fi
fi

```

