### PR TITLE
send/recv is_ubatch support ineuqal AF

### DIFF
--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -287,13 +287,14 @@ class AscendMLAMetadataBuilder:
         common_prefix_len: int,
         common_attn_metadata: AscendCommonAttentionMetadata,
         model: nn.Module,
+        is_ubatch_mode: bool = False,
     ) -> AscendMLAMetadata:
         num_reqs = common_attn_metadata.num_reqs
         num_actual_tokens = common_attn_metadata.num_actual_tokens
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
         num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = \
-            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold)
+            split_decodes_and_prefills(common_attn_metadata, decode_threshold=self.decode_threshold,is_ubatch_mode=is_ubatch_mode)
         assert num_decodes + num_prefills == num_reqs
         assert num_decode_tokens + num_prefill_tokens == num_actual_tokens
 

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -72,6 +72,7 @@ class AscendCommonAttentionMetadata:
 def split_decodes_and_prefills(
     common_attn_metadata: AscendCommonAttentionMetadata,
     decode_threshold: int = 1,
+    is_ubatch_mode: bool = False,
 ) -> tuple[int, int, int, int]:
     """
     Assuming a reordered batch, finds the boundary between prefill and decode
@@ -102,7 +103,8 @@ def split_decodes_and_prefills(
         return num_reqs, 0, num_tokens, 0
 
     first_prefill = is_prefill.int().argmax(dim=-1).item()
-    assert torch.all(query_lens[first_prefill:] > decode_threshold)
+    if not is_ubatch_mode:
+        assert torch.all(query_lens[first_prefill:] > decode_threshold)
     assert torch.all(query_lens[:first_prefill] <= decode_threshold)
     num_decodes = first_prefill
     num_prefills = num_reqs - num_decodes

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -236,14 +236,11 @@ class CAMM2NAFDConnector(AFDConnectorBase):
     
     def is_vaild_rank_for_inequal_AF(self,rank):
         # Only support ffn rank < attn rank
-        if (rank >= self.ffn_size and rank < self.ffn_size + self.min_size) or rank < self.ffn_size:
-            return True
-        return False
+        return (rank >= self.ffn_size and rank < self.ffn_size + self.min_size) or rank < self.ffn_size)
     
     def is_attn_top_min_size_rank(self,rank):
-        if rank >= self.ffn_size and rank < self.ffn_size + self.min_size:
-            return True
-        return False
+        # Only support ffn rank < attn rank
+        return (rank >= self.ffn_size and rank < self.ffn_size + self.min_size)
         
     #TODO(yxj):to support inequal AF
     def send_is_ubatch(self,data):

--- a/vllm_ascend/distributed/CAMM2NAFDConnector.py
+++ b/vllm_ascend/distributed/CAMM2NAFDConnector.py
@@ -236,7 +236,7 @@ class CAMM2NAFDConnector(AFDConnectorBase):
     
     def is_vaild_rank_for_inequal_AF(self,rank):
         # Only support ffn rank < attn rank
-        return (rank >= self.ffn_size and rank < self.ffn_size + self.min_size) or rank < self.ffn_size)
+        return ((rank >= self.ffn_size and rank < self.ffn_size + self.min_size) or rank < self.ffn_size)
     
     def is_attn_top_min_size_rank(self,rank):
         # Only support ffn rank < attn rank

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1356,7 +1356,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         # send is_ubatch to ffn side
         is_ubatch = True if ubatch_slices else False
         # to support inequal AF,[ffn_size,ffn_size + min_size) send
-        if self.afd_connector.is_attn_top_min_size_rank(self.afd_connector.rank):
+        if self.afd_connector.is_attn_top_min_size_rank(self.afd_connector.rank) and self.afd_connector:
             logger.debug(f'yxj self.afd_connector.rank in prepare input is {self.afd_connector.rank}')
             self.afd_connector.send_is_ubatch(is_ubatch)
         logger.debug(f'yxj send is_ubatch in prepare input is {is_ubatch}')
@@ -2567,7 +2567,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         # send is_ubatch to ffn side
         is_ubatch = True if ubatch_slices else False
         # to support inequal AF,[ffn_size,ffn_size + min_size) send
-        if self.afd_connector.is_attn_top_min_size_rank(self.afd_connector.rank):
+        if self.afd_connector.is_attn_top_min_size_rank(self.afd_connector.rank) and self.afd_connector:
             logger.debug(f'yxj self.afd_connector.rank in dummy_run is {self.afd_connector.rank}')
             self.afd_connector.send_is_ubatch(is_ubatch)
         logger.debug(f'send is_ubatch in dummy_run  is {is_ubatch}')

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1564,6 +1564,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                             common_prefix_len=common_prefix_len,
                             common_attn_metadata=common_attn_metadata,
                             model=self.get_model(),
+                            is_ubatch_mode=True
                         )
                         for layer_name in kv_cache_group_spec.layer_names:
                             assert type(attn_metadata) is list

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1355,8 +1355,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
             )
         # send is_ubatch to ffn side
         is_ubatch = True if ubatch_slices else False
-        self.afd_connector.send_is_ubatch(is_ubatch)
-        logger.debug(f'send is_ubatch in prepare input is {is_ubatch}')
+        # to support inequal AF,[ffn_size,ffn_size + min_size) send
+        if self.afd_connector.is_attn_top_min_size_rank(self.afd_connector.rank):
+            logger.debug(f'yxj self.afd_connector.rank in prepare input is {self.afd_connector.rank}')
+            self.afd_connector.send_is_ubatch(is_ubatch)
+        logger.debug(f'yxj send is_ubatch in prepare input is {is_ubatch}')
 
         self.seq_lens_np[:num_reqs] = (
                 self.input_batch.num_computed_tokens_cpu[:num_reqs] +
@@ -2562,8 +2565,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
         logger.info(f"dummy_run, ubatch_slices: {ubatch_slices}")
         # send is_ubatch to ffn side
         is_ubatch = True if ubatch_slices else False
-        self.afd_connector.send_is_ubatch(is_ubatch)
-        logger.debug(f'send is_ubatch in prepare input is {is_ubatch}')
+        # to support inequal AF,[ffn_size,ffn_size + min_size) send
+        if self.afd_connector.is_attn_top_min_size_rank(self.afd_connector.rank):
+            logger.debug(f'yxj self.afd_connector.rank in dummy_run is {self.afd_connector.rank}')
+            self.afd_connector.send_is_ubatch(is_ubatch)
+        logger.debug(f'send is_ubatch in dummy_run  is {is_ubatch}')
         
         num_tokens_after_padding = num_tokens
         if num_tokens_across_dp is not None:

--- a/vllm_ascend/worker/npu_ffn_model_runner_v1.py
+++ b/vllm_ascend/worker/npu_ffn_model_runner_v1.py
@@ -152,7 +152,8 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                 # TODO(yxj):ffn图模式会直接replay，应该设计成ffn收到attn消息才开始replay
                 # replay
                 if self.connector_name == "camm2nconnector":
-                    max_num_tokens = self.max_num_tokens * self.attn_size * (self.n_routed_experts // self.ffn_size) * (self.attn_size // self.ffn_size)
+                    #TODO(yxj):self.max_num_tokens * self.attn_size * (self.topk // self.ffn_size)
+                    max_num_tokens = self.max_num_tokens * self.attn_size * (self.n_routed_experts // self.ffn_size)
                 else:
                     max_num_tokens = self.max_num_tokens * self.topk * self.attn_size
                 acl_graph_info = self._acl_graphs_ubatch_full.get(max_num_tokens)
@@ -550,9 +551,8 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
                    force_attention: bool = False,
                    uniform_decode: bool = False,
                    **kwargs):
-        src = (self.connector.process_group.rank_in_group - 1) % self.connector.process_group.world_size
-        is_ubatch = self.connector.process_group.recv_object(src)
-        print(f'yxj src in _dummy_run is {src}')
+        
+        is_ubatch = self.connector.recv_is_ubatch()
         print(f'yxj is_ubatch in _dummy_run is {is_ubatch}')
         
         # only support eager mode and piecewise graph now

--- a/vllm_ascend/worker/worker_v1.py
+++ b/vllm_ascend/worker/worker_v1.py
@@ -251,7 +251,7 @@ class NPUWorker(WorkerBase):
             try:
                 while not self._ffn_shutdown_event.is_set():
                     # Execute FFN computation
-                    is_ubatch = self.recv_is_ubatch()
+                    is_ubatch = self.model_runner.connector.recv_is_ubatch()
                     self.model_runner.execute_model(scheduler_output=None,is_ubatch=is_ubatch)
             except Exception as e:
                 logger.error("FFN worker loop error: %s", e)
@@ -506,9 +506,3 @@ class NPUWorker(WorkerBase):
     def take_draft_token_ids(self) -> Optional[DraftTokenIds]:
         return self.model_runner.take_draft_token_ids()
     
-    def recv_is_ubatch(self):
-        rank = self.model_runner.connector.process_group.rank_in_group
-        world_size = self.model_runner.connector.process_group.world_size
-        src = (rank - 1) % world_size
-        is_ubatch = self.model_runner.connector.process_group.recv_object(src)
-        return is_ubatch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
send/recv is_ubatch support ineuqal AF
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

### Does this PR introduce _any_ user-facing change?
send/recv is_ubatch support ineuqal AF
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
```
#!/bin/bash
# python -m debugpy --listen 56306 --wait-for-client $(which vllm) serve /home/y00889327/DSV2LiteWeight \
# vllm serve /home/y00889327/DSV2LiteWeight \
# vllm serve /home/y00889327/DSV2LiteWeight \
#    --enable-dbo \
#    --dbo-prefill-token-threshold 12 \
#    --dbo-decode-token-threshold 2 \
# --tensor-parallel-size 2 \
# --data-parallel-size 2 \
# --enforce-eager \
# --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
#python -m debugpy --listen 56307 --wait-for-client -m vllm.entrypoints.afd_ffn_server /home/y00889327/DSV2LiteWeight\
# 用法说明
usage() {
    echo "用法: $0 [-a ATTENTION_DEVICES] [-f FFN_DEVICES] [-h]"
    echo "  参数:"
    echo "    -a ATTENTION_DEVICES  attention服务器使用的卡号（默认: 2,3）"
    echo "    -f FFN_DEVICES        ffn服务器使用的卡号（默认: 0,1）"
    echo "    -h                    显示帮助信息"
    echo ""
    echo "示例:"
    echo "  $0 -a 0,1 -f 2,3        使用卡0,1运行attention，卡2,3运行ffn"
    echo "  $0                      使用默认配置（卡2,3运行attention，卡0,1运行ffn）"
    exit 1
}

# 默认值
ATTENTION_DEVICES="14,15"
FFN_DEVICES="12,13"

# 解析命令行参数
while getopts "a:f:h" opt; do
    case $opt in
        a) ATTENTION_DEVICES="$OPTARG" ;;
        f) FFN_DEVICES="$OPTARG" ;;
        h) usage ;;
        \?) echo "无效选项: -$OPTARG" >&2; usage ;;
        :) echo "选项 -$OPTARG 需要参数" >&2; usage ;;
    esac
done

# 检查卡号是否冲突
check_device_conflict() {
    local dev1_arr=(${1//,/ })
    local dev2_arr=(${2//,/ })
    
    for dev1 in "${dev1_arr[@]}"; do
        for dev2 in "${dev2_arr[@]}"; do
            if [ "$dev1" = "$dev2" ]; then
                echo "错误: attention和ffn服务器使用了相同的卡号: $dev1"
                echo "请确保两个服务器使用不同的卡号"
                exit 1
            fi
        done
    done
}

# 检查卡号冲突
check_device_conflict "$ATTENTION_DEVICES" "$FFN_DEVICES"

echo "配置:"
echo "  Attention服务器卡号: $ATTENTION_DEVICES"
echo "  FFN服务器卡号: $FFN_DEVICES"
echo ""

# 设置公共环境变量
export HCCL_BUFFSIZE=4096
export VLLM_LOGGING_LEVEL=DEBUG

# 日志文件路径
LOG_DIR="/home/y00889327/workspace-afd/test-vllm-ascend"
ATTENTION_LOG="$LOG_DIR/attn_${ATTENTION_DEVICES//,/_}.log"
FFN_LOG="$LOG_DIR/ffn_${FFN_DEVICES//,/_}.log"

# 确保日志目录存在
mkdir -p "$LOG_DIR"

# 启动attention服务器
echo "=== 启动attention服务器（卡号: $ATTENTION_DEVICES）==="
export ASCEND_RT_VISIBLE_DEVICES="$ATTENTION_DEVICES"
nohup python -m debugpy --listen 56306 --wait-for-client $(which vllm) serve /home/y00889327/DSV2LiteWeight \
    --data-parallel-size 4 \
    --max_num_batched_tokens 20 \
    --max_num_seqs 20 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
    --enable-dbo \
    --dbo-prefill-token-threshold 12 \
    --dbo-decode-token-threshold 2 \
    --ubatch-size 2\
    --port 8006 \
    --max-model-len 4096 \
    --afd-config '{"afd_connector":"camm2nconnector", "afd_role": "attention", "num_afd_stages":"2","afd_extra_config":{"afd_size":"4A2F"}, "compute_gate_on_attention": "True","afd_port":"29666"}' \
    > "$ATTENTION_LOG" 2>&1 &
ATTENTION_PID=$!

# 记录PID
echo "attention服务器PID: $ATTENTION_PID"
echo "日志文件: $ATTENTION_LOG"

# 启动ffn服务器
echo ""
echo "=== 启动ffn服务器（卡号: $FFN_DEVICES）==="
export ASCEND_RT_VISIBLE_DEVICES="$FFN_DEVICES"
nohup python -m vllm.entrypoints.afd_ffn_server /home/y00889327/DSV2LiteWeight\
    --tensor-parallel-size 2 \
    --enable_expert_parallel \
    --max_num_batched_tokens 20 \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[20]}'  \
    --enable-dbo \
    --dbo-prefill-token-threshold 12 \
    --dbo-decode-token-threshold 2 \
    --ubatch-size 2\
    --max_num_seqs 20 \
    --max-model-len 4096 \
    --afd-config '{"afd_connector":"camm2nconnector", "num_afd_stages":"2", "afd_role": "ffn", "afd_extra_config":{"afd_size":"4A2F"}, "compute_gate_on_attention": "True","afd_port":"29666"}' \
    > "$FFN_LOG" 2>&1 &
FFN_PID=$!

# 记录PID
echo "ffn服务器PID: $FFN_PID"
echo "日志文件: $FFN_LOG"

# 保存PID到文件，方便后续管理
PIDS_FILE="$LOG_DIR/server_pids_$(date +%Y%m%d_%H%M%S).txt"
echo "ATTENTION_PID=$ATTENTION_PID" > "$PIDS_FILE"
echo "FFN_PID=$FFN_PID" >> "$PIDS_FILE"
echo "ATTENTION_LOG=$ATTENTION_LOG" >> "$PIDS_FILE"
echo "FFN_LOG=$FFN_LOG" >> "$PIDS_FILE"
echo "ATTENTION_DEVICES=$ATTENTION_DEVICES" >> "$PIDS_FILE"
echo "FFN_DEVICES=$FFN_DEVICES" >> "$PIDS_FILE"

echo ""
echo "=== 服务器启动完成 ==="
echo "两个服务器已同时拉起并运行在后台"
echo "PID文件: $PIDS_FILE"
echo ""
echo "监控日志:"
echo "  tail -f $ATTENTION_LOG"
echo "  tail -f $FFN_LOG"
echo ""
echo "停止服务器:"
echo "  kill $ATTENTION_PID $FFN_PID"
echo "或使用停止脚本: $0 stop (如果实现了停止功能)"

# 提供一个简单的监控选项
read -p "是否打开实时日志监控? (y/n): " -n 1 -r
echo ""
if [[ $REPLY =~ ^[Yy]$ ]]; then
    echo "=== 实时日志监控（Ctrl+C退出监控，服务器继续运行）==="
    echo "注意: 按 Ctrl+C 只退出监控，服务器继续在后台运行"
    echo ""
    
    # 检查是否安装了multitail
    if command -v multitail &> /dev/null; then
        multitail -s 2 \
            -l "tail -f $ATTENTION_LOG" \
            -l "tail -f $FFN_LOG" \
            -cs attention -T "Attention Server ($ATTENTION_DEVICES)" \
            -cs ffn -T "FFN Server ($FFN_DEVICES)"
    else
        echo "ATTENTION 服务器日志 ($ATTENTION_DEVICES):"
        echo "FFN 服务器日志 ($FFN_DEVICES):"
        echo "----------------------------------------"
        # 使用简单的tail -f同时查看两个日志
        (tail -f "$ATTENTION_LOG" & tail -f "$FFN_LOG") | awk '/^==>/ {print "\033[32m" $0 "\033[0m"; next} {print}'
    fi
fi

```