### PR TITLE
Add env-controlled profiler switches for model runners

### DIFF
--- a/vllm_ascend/distributed/CAMP2PAFDConnector.py
+++ b/vllm_ascend/distributed/CAMP2PAFDConnector.py
@@ -161,7 +161,7 @@ class CAMP2PAFDConnector(AFDConnectorBase):
                 self.dst_list.append(dst)
                 dst += self.min_size
 
-        self.aiv_num = int(self.config.afd_config.multistream_info["core_num"]) if self.config.afd_config.is_multistream else 48
+        self.aiv_num = int(self.config.afd_config.multistream_info["core_num"]) if self.config.afd_config.is_multistream else 8
 
         logger.debug(f"[CAM] world_rank={self.rank}, p2p_rank={self.p2p_rank}, min_size={self.min_size}, "
                      f"dst_list={self.dst_list}, cam connector initialized")

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -90,7 +90,7 @@ env_variables: Dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_SKIP_FIRST", 1500)),
     "VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR":
     lambda: os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR") or os.getenv(
-        "VLLM_TORCH_PROFILER_DIR") or "/home/j00586476/profile/attn",
+        "VLLM_TORCH_PROFILER_DIR") or "/tmp/profile/attn",
     # Whether to enable the profiler in NPUFFNModelRunner.
     "VLLM_ASCEND_FFN_PROFILER_ENABLE":
     lambda: bool(int(os.getenv("VLLM_ASCEND_FFN_PROFILER_ENABLE", '1'))),
@@ -106,7 +106,7 @@ env_variables: Dict[str, Callable[[], Any]] = {
     lambda: int(os.getenv("VLLM_ASCEND_FFN_PROFILER_SKIP_FIRST", 1500)),
     "VLLM_ASCEND_FFN_PROFILER_DIR":
     lambda: os.getenv("VLLM_ASCEND_FFN_PROFILER_DIR") or os.getenv(
-        "VLLM_TORCH_PROFILER_DIR") or "/home/j00586476/profile/ffn",
+        "VLLM_TORCH_PROFILER_DIR") or "/tmp/profile/ffn",
     # Some models are optimized by vllm ascend. While in some case, e.g. rlhf
     # training, the optimized model may not be suitable. In this case, set this
     # value to False to disable the optimized model.

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -73,6 +73,40 @@ env_variables: Dict[str, Callable[[], Any]] = {
     "VLLM_ASCEND_MODEL_EXECUTE_TIME_OBSERVE":
     lambda: bool(int(os.getenv("VLLM_ASCEND_MODEL_EXECUTE_TIME_OBSERVE", '0'))
                  ),
+    # Whether to enable the profiler in NPUModelRunner.
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_ENABLE":
+    lambda: bool(int(os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_ENABLE",
+                               '1'))),
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_WAIT":
+    lambda: int(os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_WAIT", 2)),
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_WARMUP":
+    lambda: int(os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_WARMUP", 1)),
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_ACTIVE":
+    lambda: int(os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_ACTIVE", 10)),
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_REPEAT":
+    lambda: int(os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_REPEAT", 1)),
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_SKIP_FIRST":
+    lambda: int(
+        os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_SKIP_FIRST", 1500)),
+    "VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR":
+    lambda: os.getenv("VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR") or os.getenv(
+        "VLLM_TORCH_PROFILER_DIR") or "/home/j00586476/profile/attn",
+    # Whether to enable the profiler in NPUFFNModelRunner.
+    "VLLM_ASCEND_FFN_PROFILER_ENABLE":
+    lambda: bool(int(os.getenv("VLLM_ASCEND_FFN_PROFILER_ENABLE", '1'))),
+    "VLLM_ASCEND_FFN_PROFILER_WAIT":
+    lambda: int(os.getenv("VLLM_ASCEND_FFN_PROFILER_WAIT", 2)),
+    "VLLM_ASCEND_FFN_PROFILER_WARMUP":
+    lambda: int(os.getenv("VLLM_ASCEND_FFN_PROFILER_WARMUP", 1)),
+    "VLLM_ASCEND_FFN_PROFILER_ACTIVE":
+    lambda: int(os.getenv("VLLM_ASCEND_FFN_PROFILER_ACTIVE", 20)),
+    "VLLM_ASCEND_FFN_PROFILER_REPEAT":
+    lambda: int(os.getenv("VLLM_ASCEND_FFN_PROFILER_REPEAT", 1)),
+    "VLLM_ASCEND_FFN_PROFILER_SKIP_FIRST":
+    lambda: int(os.getenv("VLLM_ASCEND_FFN_PROFILER_SKIP_FIRST", 1500)),
+    "VLLM_ASCEND_FFN_PROFILER_DIR":
+    lambda: os.getenv("VLLM_ASCEND_FFN_PROFILER_DIR") or os.getenv(
+        "VLLM_TORCH_PROFILER_DIR") or "/home/j00586476/profile/ffn",
     # Some models are optimized by vllm ascend. While in some case, e.g. rlhf
     # training, the optimized model may not be suitable. In this case, set this
     # value to False to disable the optimized model.

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -104,6 +104,7 @@ from vllm_ascend.eplb.core.eplb_worker import EplbProcess
 from vllm_ascend.eplb.eplb_updator import EplbUpdator
 from vllm_ascend.eplb.utils import model_register
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.patch.worker.patch_module import patch_torch_npu_argsort
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
@@ -378,22 +379,35 @@ class NPUModelRunner(GPUModelRunner):
 
         self.afd_comm_stream = torch.npu.Stream()
         
-        import os
-        experimental_config = torch_npu.profiler._ExperimentalConfig(
-            export_type=torch_npu.profiler.ExportType.Text,
-            profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
-            aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
-        )
-        self.prof = torch_npu.profiler.profile(
-            activities=[
-                torch_npu.profiler.ProfilerActivity.CPU,
-                torch_npu.profiler.ProfilerActivity.NPU
-            ],
-            schedule=torch_npu.profiler.schedule(wait=2, warmup=1, active=10, repeat=1, skip_first=1500),
-            # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
-            experimental_config=experimental_config,
-            on_trace_ready=torch_npu.profiler.tensorboard_trace_handler("/home/j00586476/profile/attn")
-        )
+        self.prof = None
+        if envs_ascend.VLLM_ASCEND_MODEL_RUNNER_PROFILER_ENABLE:
+            experimental_config = torch_npu.profiler._ExperimentalConfig(
+                export_type=torch_npu.profiler.ExportType.Text,
+                profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
+                aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+            )
+            logger.info(
+                "NPUModelRunner profiler enabled. Traces will be saved to: %s",
+                envs_ascend.VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR)
+            self.prof = torch_npu.profiler.profile(
+                activities=[
+                    torch_npu.profiler.ProfilerActivity.CPU,
+                    torch_npu.profiler.ProfilerActivity.NPU
+                ],
+                schedule=torch_npu.profiler.schedule(
+                    wait=envs_ascend.VLLM_ASCEND_MODEL_RUNNER_PROFILER_WAIT,
+                    warmup=envs_ascend.
+                    VLLM_ASCEND_MODEL_RUNNER_PROFILER_WARMUP,
+                    active=envs_ascend.
+                    VLLM_ASCEND_MODEL_RUNNER_PROFILER_ACTIVE,
+                    repeat=envs_ascend.
+                    VLLM_ASCEND_MODEL_RUNNER_PROFILER_REPEAT,
+                    skip_first=envs_ascend.
+                    VLLM_ASCEND_MODEL_RUNNER_PROFILER_SKIP_FIRST),
+                # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
+                experimental_config=experimental_config,
+                on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(
+                    envs_ascend.VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR))
 
     def _init_device_properties(self) -> None:
         self.num_sms = None
@@ -1613,7 +1627,8 @@ class NPUModelRunner(GPUModelRunner):
         scheduler_output: "SchedulerOutput",
         intermediate_tensors: Optional[IntermediateTensors] = None,
     ) -> Union[ModelRunnerOutput, IntermediateTensors] | None:
-        self.prof.step()
+        if self.prof is not None:
+            self.prof.step()
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called "
                                "after execute_model() returns None.")

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1718,6 +1718,7 @@ class NPUModelRunner(GPUModelRunner):
                         )
                         logger.info(f'afd_connector.rank send_dp_metadata_list is {dp_metadata_list}, '
                                     f'is_warmup: {self._is_warmup}, ubatch_slices: {ubatch_slices}')
+                    dist.barrier(group=get_dp_group().cpu_group)
                 hidden_states = self._generate_process_reqs_hidden_states(
                     maybe_padded_num_tokens, input_ids, positions,
                     intermediate_tensors, inputs_embeds, model_kwargs)
@@ -2592,6 +2593,8 @@ class NPUModelRunner(GPUModelRunner):
                         )
                         logger.info(f'afd_connector.rank in dummy_run send_dp_metadata_list is {dp_metadata_list}, '
                                     f'is_graph_capturing: {is_graph_capturing}, is_warmup: {self._is_warmup}')
+                    dist.barrier(group=get_dp_group().cpu_group)
+
                 hidden_states = self._generate_dummy_run_hidden_states(
                     input_ids, positions, num_tokens_padded,
                     intermediate_tensors, inputs_embeds)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -377,24 +377,23 @@ class NPUModelRunner(GPUModelRunner):
         self.long_seq_metadata = None
 
         self.afd_comm_stream = torch.npu.Stream()
-        #
-        # import os
-        # experimental_config = torch_npu.profiler._ExperimentalConfig(
-        #     export_type=torch_npu.profiler.ExportType.Text,
-        #     profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
-        #     aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
-        # )
-        # self.prof = torch_npu.profiler.profile(
-        #     activities=[
-        #         torch_npu.profiler.ProfilerActivity.CPU,
-        #         torch_npu.profiler.ProfilerActivity.NPU
-        #     ],
-        #     schedule=torch_npu.profiler.schedule(wait=2, warmup=1, active=10, repeat=1, skip_first=1500),
-        #     # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
-        #     experimental_config=experimental_config,
-        #     on_trace_ready=torch_npu.profiler.tensorboard_trace_handler("/home/y00889327/prof")
-        # )
-        # self.prof.start()
+        
+        import os
+        experimental_config = torch_npu.profiler._ExperimentalConfig(
+            export_type=torch_npu.profiler.ExportType.Text,
+            profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
+            aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+        )
+        self.prof = torch_npu.profiler.profile(
+            activities=[
+                torch_npu.profiler.ProfilerActivity.CPU,
+                torch_npu.profiler.ProfilerActivity.NPU
+            ],
+            schedule=torch_npu.profiler.schedule(wait=2, warmup=1, active=10, repeat=1, skip_first=1500),
+            # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
+            experimental_config=experimental_config,
+            on_trace_ready=torch_npu.profiler.tensorboard_trace_handler("/home/j00586476/profile/attn")
+        )
 
     def _init_device_properties(self) -> None:
         self.num_sms = None
@@ -1614,7 +1613,7 @@ class NPUModelRunner(GPUModelRunner):
         scheduler_output: "SchedulerOutput",
         intermediate_tensors: Optional[IntermediateTensors] = None,
     ) -> Union[ModelRunnerOutput, IntermediateTensors] | None:
-        # self.prof.step()
+        self.prof.step()
         if self.execute_model_state is not None:
             raise RuntimeError("State error: sample_tokens() must be called "
                                "after execute_model() returns None.")

--- a/vllm_ascend/worker/npu_ffn_model_runner_v1.py
+++ b/vllm_ascend/worker/npu_ffn_model_runner_v1.py
@@ -105,23 +105,23 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             self.uniform_decode_query_len
         )
 
-        # self.profiler
-        # import os
-        # experimental_config = torch_npu.profiler._ExperimentalConfig(
-        #     export_type=torch_npu.profiler.ExportType.Text,
-        #     profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
-        #     aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
-        # )
-        # self.prof = torch_npu.profiler.profile(
-        #     activities=[
-        #         torch_npu.profiler.ProfilerActivity.CPU,
-        #         torch_npu.profiler.ProfilerActivity.NPU
-        #     ],
-        #     schedule=torch_npu.profiler.schedule(wait=2, warmup=1, active=10, repeat=1, skip_first=1500),
-        #     # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
-        #     experimental_config=experimental_config,
-        #     on_trace_ready=torch_npu.profiler.tensorboard_trace_handler("/home/y00889327/prof_ffn")
-        # )
+        self.profiler
+        import os
+        experimental_config = torch_npu.profiler._ExperimentalConfig(
+            export_type=torch_npu.profiler.ExportType.Text,
+            profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
+            aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+        )
+        self.prof = torch_npu.profiler.profile(
+            activities=[
+                torch_npu.profiler.ProfilerActivity.CPU,
+                torch_npu.profiler.ProfilerActivity.NPU
+            ],
+            schedule=torch_npu.profiler.schedule(wait=2, warmup=1, active=20, repeat=1, skip_first=1500),
+            # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
+            experimental_config=experimental_config,
+            on_trace_ready=torch_npu.profiler.tensorboard_trace_handler("/home/j00586476/profile/ffn")
+        )
         # self.prof.start()
 
     def get_model(self) -> nn.Module:
@@ -143,6 +143,7 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             intermediate_tensors: 中间张量（FFN侧通常为None）
             dp_metadata_list: dp_metadata列表，包含每个stage的token数量信息
         """
+        self.prof.step()
         try:
             # 从dp_metadata_list中获取is_ubatch
             is_ubatch = dp_metadata_list is not None and len(dp_metadata_list) > 1

--- a/vllm_ascend/worker/npu_ffn_model_runner_v1.py
+++ b/vllm_ascend/worker/npu_ffn_model_runner_v1.py
@@ -28,6 +28,7 @@ from vllm_ascend.worker.model_runner_v1 import (NPUModelRunner, graph_capture,
                                               _replace_gpu_model_runner_function_wrapper)
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.distributed.metadata import (M2NAFDConnectorMetadata, CAMM2NAFDConnectorMetadata, CAMP2PAFDConnectorMetadata)
+import vllm_ascend.envs as envs_ascend
 from vllm.compilation.monitor import set_cudagraph_capturing_enabled
 from vllm.config import (CompilationMode, CUDAGraphMode, VllmConfig,
                          get_layers_from_vllm_config)
@@ -105,24 +106,31 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             self.uniform_decode_query_len
         )
 
-        self.profiler
-        import os
-        experimental_config = torch_npu.profiler._ExperimentalConfig(
-            export_type=torch_npu.profiler.ExportType.Text,
-            profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
-            aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
-        )
-        self.prof = torch_npu.profiler.profile(
-            activities=[
-                torch_npu.profiler.ProfilerActivity.CPU,
-                torch_npu.profiler.ProfilerActivity.NPU
-            ],
-            schedule=torch_npu.profiler.schedule(wait=2, warmup=1, active=20, repeat=1, skip_first=1500),
-            # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
-            experimental_config=experimental_config,
-            on_trace_ready=torch_npu.profiler.tensorboard_trace_handler("/home/j00586476/profile/ffn")
-        )
-        # self.prof.start()
+        self.prof = None
+        if envs_ascend.VLLM_ASCEND_FFN_PROFILER_ENABLE:
+            experimental_config = torch_npu.profiler._ExperimentalConfig(
+                export_type=torch_npu.profiler.ExportType.Text,
+                profiler_level=torch_npu.profiler.ProfilerLevel.Level2,
+                aic_metrics=torch_npu.profiler.AiCMetrics.AiCoreNone,
+            )
+            logger.info(
+                "NPUFFNModelRunner profiler enabled. Traces will be saved to: %s",
+                envs_ascend.VLLM_ASCEND_FFN_PROFILER_DIR)
+            self.prof = torch_npu.profiler.profile(
+                activities=[
+                    torch_npu.profiler.ProfilerActivity.CPU,
+                    torch_npu.profiler.ProfilerActivity.NPU
+                ],
+                schedule=torch_npu.profiler.schedule(
+                    wait=envs_ascend.VLLM_ASCEND_FFN_PROFILER_WAIT,
+                    warmup=envs_ascend.VLLM_ASCEND_FFN_PROFILER_WARMUP,
+                    active=envs_ascend.VLLM_ASCEND_FFN_PROFILER_ACTIVE,
+                    repeat=envs_ascend.VLLM_ASCEND_FFN_PROFILER_REPEAT,
+                    skip_first=envs_ascend.VLLM_ASCEND_FFN_PROFILER_SKIP_FIRST),
+                # 初步采集最好不要使用下面两个选项， with_stack 会大幅增加采集时间及采集的数据大小，深入分析CPU测瓶颈时再打开
+                experimental_config=experimental_config,
+                on_trace_ready=torch_npu.profiler.tensorboard_trace_handler(
+                    envs_ascend.VLLM_ASCEND_FFN_PROFILER_DIR))
 
     def get_model(self) -> nn.Module:
         return self.model
@@ -143,7 +151,8 @@ class NPUFFNModelRunner(NPUModelRunner,GPUFFNModelRunner):
             intermediate_tensors: 中间张量（FFN侧通常为None）
             dp_metadata_list: dp_metadata列表，包含每个stage的token数量信息
         """
-        self.prof.step()
+        if self.prof is not None:
+            self.prof.step()
         try:
             # 从dp_metadata_list中获取is_ubatch
             is_ubatch = dp_metadata_list is not None and len(dp_metadata_list) > 1

--- a/vllm_ascend/worker/npu_ubatch_wrapper.py
+++ b/vllm_ascend/worker/npu_ubatch_wrapper.py
@@ -382,7 +382,6 @@ class UBatchWrapper(GPUUBatchWrapper):
                 return self.runnable(*args, **kwargs)
             else:
                 assert self.aclgraph_wrapper is not None
-                print("jcz ubatch wrapper 2")
                 return self.aclgraph_wrapper(*args, **kwargs)
 
         attn_metadata = forward_context.attn_metadata

--- a/vllm_ascend/worker/npu_ubatch_wrapper.py
+++ b/vllm_ascend/worker/npu_ubatch_wrapper.py
@@ -382,6 +382,7 @@ class UBatchWrapper(GPUUBatchWrapper):
                 return self.runnable(*args, **kwargs)
             else:
                 assert self.aclgraph_wrapper is not None
+                print("jcz ubatch wrapper 2")
                 return self.aclgraph_wrapper(*args, **kwargs)
 
         attn_metadata = forward_context.attn_metadata


### PR DESCRIPTION
This PR adds environment-variable control for the NPUModelRunner and NPUFFNModelRunner profilers, including enable flags, schedule parameters, and trace output directories. It also keeps the legacy trace directory env as a fallback for compatibility.

For example:
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_ENABLE=1
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_WAIT=2
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_WARMUP=1
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_ACTIVE=10
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_REPEAT=1
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_SKIP_FIRST=1500
export VLLM_ASCEND_MODEL_RUNNER_PROFILER_DIR="/home/j00586476/profile/attn"
export VLLM_ASCEND_FFN_PROFILER_ENABLE=1
export VLLM_ASCEND_FFN_PROFILER_WAIT=2
export VLLM_ASCEND_FFN_PROFILER_WARMUP=1
export VLLM_ASCEND_FFN_PROFILER_ACTIVE=20
export VLLM_ASCEND_FFN_PROFILER_REPEAT=1
export VLLM_ASCEND_FFN_PROFILER_SKIP_FIRST=1500
export VLLM_ASCEND_FFN_PROFILER_DIR="/home/j00586476/profile/ffn"