### PR TITLE
Refine force load balance routing for Ascend fused MoE

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -272,9 +272,10 @@ class AscendFusedMoE(FusedMoE):
                 in ("GPTQMarlinMoEMethod", "CompressedTensorsWNA16MoEMethod")):
             moe_quant_params["intermediate_size_full"] = intermediate_size
         self.quant_method.create_weights(layer=self, **moe_quant_params)
-        if (self.enable_force_load_balance
-                and isinstance(self.quant_method,
-                               AscendUnquantizedFusedMoEMethod)):
+        if (self.enable_force_load_balance and isinstance(
+                self.quant_method,
+            (AscendUnquantizedFusedMoEMethod,
+             AscendW8A8DynamicFusedMoEMethod))):
             self._validate_force_lb_config()
             self._init_force_lb_buffer(max_tokens=self.max_force_lb_tokens,
                                        device=self.w13_weight.device)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -272,10 +272,7 @@ class AscendFusedMoE(FusedMoE):
                 in ("GPTQMarlinMoEMethod", "CompressedTensorsWNA16MoEMethod")):
             moe_quant_params["intermediate_size_full"] = intermediate_size
         self.quant_method.create_weights(layer=self, **moe_quant_params)
-        if (self.enable_force_load_balance and isinstance(
-                self.quant_method,
-            (AscendUnquantizedFusedMoEMethod,
-             AscendW8A8DynamicFusedMoEMethod))):
+        if self.enable_force_load_balance:
             self._validate_force_lb_config()
             self._init_force_lb_buffer(max_tokens=self.max_force_lb_tokens,
                                        device=self.w13_weight.device)

--- a/vllm_ascend/quantization/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/w8a8_dynamic.py
@@ -251,6 +251,17 @@ class AscendW8A8DynamicFusedMoEMethod:
                                        device=topk_ids.device)
             topk_ids = torch.argsort(
                 random_matrix, dim=1)[:, :topk_ids.size(1)].to(topk_ids.dtype)
+        elif layer.enable_force_load_balance:
+            fake_routed_topk_ids = layer._get_force_lb_topk_ids(
+                batch_tokens=topk_ids.shape[0], device=topk_ids.device)
+            if fake_routed_topk_ids is not None:
+                fake_routed_topk_ids = fake_routed_topk_ids.to(topk_ids.dtype)
+                if layer.mix_placement:
+                    shared_topk_ids = topk_ids[:, top_k:]
+                    topk_ids = torch.cat([fake_routed_topk_ids, shared_topk_ids],
+                                         dim=1)
+                else:
+                    topk_ids = fake_routed_topk_ids
 
         assert topk_weights is not None
         topk_weights = topk_weights.to(self.in_dtype)


### PR DESCRIPTION
This PR refines Ascend fused MoE force-load-balance routing.

Highlights:
- Keep the original in_profile_run random topk_ids logic unchanged.
- Add the prebuilt force-load-balance buffer path for the unquantized path.
- Add the same buffer routing path for W8A8.
- Support additional_config.force_load_balance_topn_per_rank.
- Log the constructed force-load-balance buffer preview during initialization.

How to use the new force-load-balance path:
vllm serve <model> --additional-config '{"enable_force_load_balance": true, "force_load_balance_topn_per_rank": 2}'

Notes:
- enable_force_load_balance=true enables the prebuilt buffer path.
- force_load_balance_topn_per_rank is optional.
- The original in_profile_run random topk_ids path remains unchanged.